### PR TITLE
Implemented object parser.

### DIFF
--- a/src/Yosymfony/Toml/ObjectParser.php
+++ b/src/Yosymfony/Toml/ObjectParser.php
@@ -1,0 +1,488 @@
+<?php
+
+/*
+ * This file is part of the Yosymfony\Toml package.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yosymfony\Toml;
+
+use Yosymfony\Toml\Exception\ParseException;
+use stdClass;
+
+/**
+ * Parser for Toml strings (0.2.0 specification).
+ *
+ * This parser produces generic (stdClass) objects instead of associative arrays.
+ *
+ * @author Victor Puertas <vpgugr@vpgugr.com>
+ */
+class ObjectParser
+{
+    private $lexer = null;
+    private $currentLine = 0;
+    private $data = null;
+    private $result;
+    private $tableNames = array();
+    private $arrayTableNames = array();
+    private $invalidArrayTablesName = array();
+
+    public function __construct()
+    {
+        $this->result = new stdClass;
+        $this->data = &$this->result;
+    }
+
+    /**
+     * Parses TOML string into a PHP value.
+     *
+     * @param string $value A TOML string
+     *
+     * @return mixed A PHP value
+     */
+    public function parse($value)
+    {
+        $this->lexer = new Lexer($value);
+        $this->lexer->getToken();
+
+        $resultIsEmpty = true;
+        while($this->lexer->getCurrentToken()->getType() !== Lexer::TOKEN_EOF)
+        {
+            switch($this->lexer->getCurrentToken()->getType())
+            {
+                case Lexer::TOKEN_HASH:
+                    $this->processComment();        // #comment
+                    break;
+                case Lexer::TOKEN_LBRANK:
+                    $resultIsEmpty = false;
+                    $this->processTables();         // [table] or [[array of tables]]
+                    break;
+                case Lexer::TOKEN_LITERAL:
+                    $resultIsEmpty = false;
+                    $this->processKeyValue();       // key = value
+                    break;
+                case Lexer::TOKEN_NEWLINE:
+                    $this->currentLine++;
+                    break;
+            }
+
+            $this->lexer->getToken();
+        }
+
+        if ($resultIsEmpty) {
+            return null;
+        }
+
+        return $this->result;
+    }
+
+    private function processComment()
+    {
+        while($this->isTokenValidForComment($this->lexer->getToken()))
+        {
+            // do nothing
+        }
+    }
+
+    private function isTokenValidForComment(Token $token)
+    {
+        return Lexer::TOKEN_NEWLINE !== $token->getType() && Lexer::TOKEN_EOF !== $token->getType();
+    }
+
+    private function processTables()
+    {
+        if(Lexer::TOKEN_LBRANK === $this->lexer->getNextToken()->getType())
+        {
+            $this->processArrayOfTables();
+        }
+        else
+        {
+            $this->processTable();
+        }
+
+        $finalTokenType = $this->lexer->getToken()->getType();
+
+        switch($finalTokenType)
+        {
+            case Lexer::TOKEN_NEWLINE:
+                $this->currentLine++;
+                break;
+            case Lexer::TOKEN_HASH:
+                $this->processComment();
+                break;
+            case Lexer::TOKEN_EOF:
+                break;
+            default:
+                throw new ParseException(
+                    'Syntax error: expected new line or EOF after table/array of tables value',
+                    $this->currentLine,
+                    $this->lexer->getCurrentToken()->getValue());
+        }
+    }
+
+    private function processArrayOfTables()
+    {
+        $key = '';
+
+        $this->lexer->getToken();
+
+        while($this->isTokenValidForTablename($this->lexer->getToken()))
+        {
+            $key .= $this->lexer->getCurrentToken()->getValue();
+        }
+
+        $this->setArrayOfTables($key);
+
+        $currentTokenType = $this->lexer->getCurrentToken()->getType();
+        $nextTokenType = $this->lexer->getToken()->getType();
+
+        if(Lexer::TOKEN_RBRANK !== $currentTokenType || Lexer::TOKEN_RBRANK !== $nextTokenType)
+        {
+            throw new ParseException(
+                'Syntax error: expected close brank',
+                $this->currentLine,
+                $this->lexer->getCurrentToken()->getValue());
+        }
+    }
+
+    private function processTable()
+    {
+        $key = '';
+
+        while($this->isTokenValidForTablename($this->lexer->getToken()))
+        {
+            $key .= $this->lexer->getCurrentToken()->getValue();
+        }
+
+        $this->setTable($key);
+
+        if(Lexer::TOKEN_RBRANK !== $this->lexer->getCurrentToken()->getType())
+        {
+            throw new ParseException(
+                'Syntax error: expected close brank',
+                $this->currentLine,
+                $this->lexer->getCurrentToken()->getValue());
+        }
+    }
+
+    private function isTokenValidForTablename(Token $token)
+    {
+        if(Lexer::TOKEN_HASH === $token->getType())
+        {
+            $this->lexer->setCommentOpen(false);
+
+            return true;
+        }
+
+        return Lexer::TOKEN_LITERAL === $token->getType();
+    }
+
+    private function setTable($key)
+    {
+        $nameParts = explode('.', $key);
+        $this->data = &$this->result;
+
+        if(in_array($key, $this->tableNames) || in_array($key, $this->arrayTableNames))
+        {
+            throw new ParseException(
+                sprintf('Syntax error: the table %s has already been defined', $key),
+                $this->currentLine, $this->lexer->getCurrentToken()->getValue());
+        }
+
+        $this->tableNames[] = $key;
+
+        foreach($nameParts as $namePart)
+        {
+            if(0 == strlen($namePart))
+            {
+                throw new ParseException('The name of the table must not be empty', $this->currentLine, $key);
+            }
+
+            if(property_exists($this->data, $namePart))
+            {
+                if(!is_object($this->data->$namePart))
+                {
+                    throw new ParseException(
+                        sprintf('Syntax error: the table %s has already been defined', $key),
+                        $this->currentLine, $this->lexer->getCurrentToken()->getValue());
+                }
+            }
+            else
+            {
+                $this->data->$namePart = new stdClass;
+            }
+
+            $this->data = &$this->data->$namePart;
+        }
+    }
+
+    private function setArrayOfTables($key)
+    {
+        $nameParts = explode('.', $key);
+        $endIndex = count($nameParts) - 1;
+
+        if(true == $this->isTableImplicit($nameParts))
+        {
+            $this->addInvalidArrayTablesName($nameParts);
+            $this->setTable($key);
+
+            return;
+        }
+
+        if(in_array($key, $this->invalidArrayTablesName))
+        {
+            throw new ParseException(
+                sprintf('Syntax error: the array of tables %s has already been defined as previous table', $key),
+                $this->currentLine, $this->lexer->getCurrentToken()->getValue());
+        }
+
+        $this->data = &$this->result;
+        $this->arrayTableNames[] = $key;
+
+        foreach($nameParts as $index => $namePart)
+        {
+            if(0 == strlen($namePart))
+            {
+                throw new ParseException('The key must not be empty', $this->currentLine, $key);
+            }
+
+            if(false == property_exists($this->data, $namePart))
+            {
+                $this->data->$namePart = array();
+                $this->data->{$namePart}[] = new stdClass;
+            }
+            else if($endIndex == $index)
+            {
+                $this->data->{$namePart}[] = new stdClass;
+            }
+
+            $this->data = &$this->getLastElementRef($this->data->$namePart);
+        }
+    }
+
+    private function processKeyValue()
+    {
+        $key = $this->lexer->getCurrentToken()->getValue();
+
+        while($this->isTokenValidForKey($this->lexer->getToken()))
+        {
+            $key = $key . $this->lexer->getCurrentToken()->getValue();
+        }
+
+        if(Lexer::TOKEN_EQUAL !== $this->lexer->getCurrentToken()->getType())
+        {
+            throw new ParseException(
+                'Syntax error: expected equal',
+                $this->currentLine,
+                $this->lexer->getCurrentToken()->getValue());
+        }
+
+        $key = trim($key);
+
+        if(property_exists($this->data, $key))
+        {
+            throw new ParseException(
+                sprintf('Syntax error: the key %s has already been defined', $key),
+                $this->currentLine,
+                $this->lexer->getCurrentToken()->getValue());
+        }
+
+        switch($this->lexer->getToken()->getType())
+        {
+            case Lexer::TOKEN_QUOTES:
+                $this->data->$key = $this->getStringValue();
+                break;
+            case Lexer::TOKEN_LBRANK:
+                $this->data->$key = $this->getArrayValue();
+                break;
+            case Lexer::TOKEN_LITERAL:
+                $this->data->$key = $this->getLiteralValue();
+                break;
+            default:
+                throw new ParseException(
+                    'Syntax error: expected data type',
+                    $this->currentLine,
+                    $this->lexer->getCurrentToken()->getValue());
+        }
+    }
+
+    private function isTokenValidForKey(Token $token)
+    {
+        return Lexer::TOKEN_EQUAL  !== $token->getType()
+            && Lexer::TOKEN_NEWLINE !== $token->getType()
+            && Lexer::TOKEN_EOF !== $token->getType();
+    }
+
+    private function getStringValue()
+    {
+        $result = "";
+
+        if(Lexer::TOKEN_STRING !== $this->lexer->getToken()->getType())
+        {
+            throw new ParseException(
+                'Syntax error: expected string',
+                $this->currentLine,
+                $this->lexer->getCurrentToken()->getValue());
+        }
+
+        $result = (string) $this->lexer->getCurrentToken()->getValue();
+
+        if(Lexer::TOKEN_QUOTES !== $this->lexer->getToken()->getType())
+        {
+            throw new ParseException(
+                'Syntax error: expected close quotes',
+                $this->currentLine,
+                $this->lexer->getCurrentToken()->getValue());
+        }
+
+        return $result;
+    }
+
+    private function getArrayValue()
+    {
+        $result = array();
+        $dataType = null;
+        $lastType = null;
+        $value = null;
+
+        while(Lexer::TOKEN_RBRANK != $this->lexer->getToken()->getType())
+        {
+            switch($this->lexer->getCurrentToken()->getType())
+            {
+                case Lexer::TOKEN_COMMA:
+                    if($dataType == null)
+                    {
+                        throw new ParseException('Expected data type before comma', $this->currentLine, $value);
+                    }
+                    break;
+                case Lexer::TOKEN_QUOTES:
+                    $lastType = 'string';
+                    $dataType = $dataType == null ? $lastType : $dataType;
+                    $value = $this->getStringValue();
+                    $result[] = $value;
+                    break;
+                case Lexer::TOKEN_LBRANK:
+                    $lastType = 'array';
+                    $dataType = $dataType == null ? $lastType : $dataType;
+                    $result[] = $this->getArrayValue();
+                    break;
+                case Lexer::TOKEN_LITERAL:
+                    $value = $this->getLiteralValue();
+                    $lastType =  gettype($value);
+                    $dataType = $dataType == null ? $lastType : $dataType;
+                    $result[] = $value;
+                    break;
+                case Lexer::TOKEN_HASH:
+                    $this->processComment();
+                    break;
+                case Lexer::TOKEN_NEWLINE:
+                    $this->currentLine++;
+                    break;
+                case Lexer::TOKEN_RBRANK:
+                    break;
+                default:
+                    throw new ParseException('Syntax error', $this->currentLine, $this->lexer->getCurrentToken()->getValue());
+            }
+
+            if($lastType != $dataType)
+            {
+                throw new ParseException('Data types cannot be mixed in an array', $this->currentLine, $value);
+            }
+        }
+
+        return $result;
+    }
+
+    private function getLiteralValue()
+    {
+        $token = $this->lexer->getCurrentToken();
+
+        if($this->isLiteralBoolean($token))
+        {
+            return $token->getValue() == 'true' ? true : false;
+        }
+
+        if($this->isLiteralInteger($token))
+        {
+            return (int) $token->getValue();
+        }
+
+        if($this->isLiteralFloat($token))
+        {
+            return (float) $token->getValue();
+        }
+
+        if($this->isLiteralISO8601($token))
+        {
+            return new \Datetime($token->getValue());
+        }
+
+        throw new ParseException('Unknown value type', $this->currentLine, $token->getValue());
+    }
+
+    private function isLiteralBoolean(Token $token)
+    {
+        $result = false;
+
+        switch($token->getValue())
+        {
+            case 'true':
+            case 'false':
+                $result = true;
+        }
+
+        return $result;
+    }
+
+    private function isLiteralInteger(Token $token)
+    {
+        return  preg_match('/^\-?\d*?$/', $token->getValue());
+    }
+
+    private function isLiteralFloat(Token $token)
+    {
+        return preg_match('/^\-?\d+\.\d+$/', $token->getValue());
+    }
+
+    private function isLiteralISO8601(Token $token)
+    {
+        return preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $token->getValue());
+    }
+
+    private function &getLastElementRef(&$array)
+    {
+        end($array);
+
+        return $array[key($array)];
+    }
+
+    private function isTableImplicit(array $tablenameParts)
+    {
+        if(count($tablenameParts) > 1)
+        {
+            array_pop($tablenameParts);
+
+            $tablename = implode('.', $tablenameParts);
+
+            if(false == in_array($tablename, $this->arrayTableNames))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function addInvalidArrayTablesName(array $tablenameParts)
+    {
+        foreach($tablenameParts as $part)
+        {
+            $this->invalidArrayTablesName[] = implode('.', $tablenameParts);
+            array_pop($tablenameParts);
+        }
+    }
+}

--- a/tests/ObjectParserInvalidTest.php
+++ b/tests/ObjectParserInvalidTest.php
@@ -1,0 +1,376 @@
+<?php
+
+/*
+ * This file is part of the Yosymfony\Toml package.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yosymfony\Toml\Tests;
+
+use Yosymfony\Toml\Exception\ParseException;
+use Yosymfony\Toml\Lexer;
+use Yosymfony\Toml\ObjectParser;
+use Yosymfony\Toml\Token;
+use Yosymfony\Toml\Toml;
+
+/*
+ * Tests based on toml-test from BurntSushi
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+
+ * @see https://github.com/BurntSushi/toml-test/tree/master/tests/invalid
+ */
+class ObjectParserInvalidTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testArrayMixedTypesArraysAndInts()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('arrays-and-ints =  [1, ["Arrays are not integers."]]');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testArrayMixedTypesIntsAndFloats()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('ints-and-floats = [1, 1.0]');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testArrayMixedTypesStringsAndInts()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('strings-and-ints = ["hi", 42]');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDatetimeMalformedNoLeads()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('no-leads = 1987-7-05T17:45:00Z');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDatetimeMalformedNoSecs()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('no-secs = 1987-07-05T17:45Z');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDatetimeMalformedNoT()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('no-t = 1987-07-0517:45:00Z');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDatetimeMalformedNoZ()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('no-z = 1987-07-05T17:45:00');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDatetimeMalformedWithMilli()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('with-milli = 1987-07-5T17:45:00.12Z');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDuplicateKeyTable()
+    {
+        $filename = __DIR__.'/fixtures/invalid/duplicateKeyTable.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDuplicateTable()
+    {
+        $filename = __DIR__.'/fixtures/invalid/duplicateTable.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testDuplicateKeys()
+    {
+        $filename = __DIR__.'/fixtures/invalid/duplicateKeys.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testEmptyImplicitTable()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('[naughty..naughty]');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testEmptyTable()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('[]');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testFloatNoLeadingZero()
+    {
+        $filename = __DIR__.'/fixtures/invalid/floatNoLeadingZero.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testFloatNoTrailingDigits()
+    {
+        $filename = __DIR__.'/fixtures/invalid/floatNoTrailingDigits.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testKeyTwoEquals()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('key= = 1');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\LexerException
+     */
+    public function testStringBadByteEscape()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('naughty = "\xAg"');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\LexerException
+     */
+    public function testStringBadEscape()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('invalid-escape = "This string has a bad \a escape character."');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\LexerException
+     */
+    public function testStringByteEscapes()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('answer = "\x33"');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testStringNoClose()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('no-ending-quote = "One time, at band camp');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTextAfterArrayEntries()
+    {
+        $filename = __DIR__.'/fixtures/invalid/textAfterArrayEntries.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTextAfterInteger()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('answer = 42 the ultimate answer?');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTextAfterTable()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('[error] this shouldn\'t be here');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTextAfterString()
+    {
+        $parser = new ObjectParser();
+
+        $array = $parser->parse('string = "Is there life after strings?" No.');
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTextBeforeArraySeparator()
+    {
+        $filename = __DIR__.'/fixtures/invalid/textBeforeArraySeparator.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTextInArray()
+    {
+        $filename = __DIR__.'/fixtures/invalid/textInArray.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTableArrayImplicit()
+    {
+        $filename = __DIR__.'/fixtures/invalid/tableArrayImplicit.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTableArrayMalformedBracket()
+    {
+        $filename = __DIR__.'/fixtures/invalid/tableArrayMalformedBracket.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTableArrayMalformedEmpty()
+    {
+        $filename = __DIR__.'/fixtures/invalid/tableArrayMalformedEmpty.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTableNestedBracketsClose()
+    {
+        $filename = __DIR__.'/fixtures/invalid/tableNestedBracketsClose.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTableNestedBracketsOpen()
+    {
+        $filename = __DIR__.'/fixtures/invalid/tableNestedBracketsOpen.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+
+    /**
+     * @expectedException \Yosymfony\Toml\Exception\ParseException
+     */
+    public function testTableArrayWithSomeNameOfTable()
+    {
+        $filename = __DIR__.'/fixtures/invalid/tableArrayWithSomeNameOfTable.toml';
+
+        $parser = new ObjectParser();
+
+        $array = $parser->parse(file_get_contents($filename));
+    }
+}

--- a/tests/ObjectParserTest.php
+++ b/tests/ObjectParserTest.php
@@ -1,0 +1,537 @@
+<?php
+
+/*
+ * This file is part of the Yosymfony\Toml package.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yosymfony\Toml\Tests;
+
+use Yosymfony\Toml\Exception\ParseException;
+use Yosymfony\Toml\Lexer;
+use Yosymfony\Toml\ObjectParser;
+use Yosymfony\Toml\Token;
+use Yosymfony\Toml\Toml;
+
+/*
+ * Tests based on toml-test from BurntSushi
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+
+ * @see https://github.com/BurntSushi/toml-test/tree/master/tests/valid
+ */
+class ObjectParserTest extends \PHPUnit_Framework_TestCase
+{
+    public function testArrayEmpty()
+    {
+        date_default_timezone_set('UTC');
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('thevoid = [[[[[]]]]]');
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('thevoid', $object);
+
+        $this->assertTrue(is_array($object->thevoid));
+        $this->assertTrue(is_array($object->thevoid[0]));
+        $this->assertTrue(is_array($object->thevoid[0][0]));
+        $this->assertTrue(is_array($object->thevoid[0][0][0]));
+        $this->assertTrue(is_array($object->thevoid[0][0][0][0]));
+    }
+
+    public function testArraysHeterogeneous()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('mixed = [[1, 2], ["a", "b"], [1.0, 2.0]]');
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('mixed', $object);
+
+        $this->assertTrue(is_array($object->mixed[0]));
+        $this->assertTrue(is_array($object->mixed[1]));
+        $this->assertTrue(is_array($object->mixed[2]));
+
+        $this->assertEquals($object->mixed[0][0], 1);
+        $this->assertEquals($object->mixed[0][1], 2);
+
+        $this->assertEquals($object->mixed[1][0], 'a');
+        $this->assertEquals($object->mixed[1][1], 'b');
+
+        $this->assertEquals($object->mixed[2][0], 1.0);
+        $this->assertEquals($object->mixed[2][1], 2.0);
+    }
+
+    public function testArraysNested()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('nest = [["a"], ["b"]]');
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('nest', $object);
+
+        $this->assertTrue(is_array($object->nest[0]));
+        $this->assertTrue(is_array($object->nest[1]));
+
+        $this->assertEquals($object->nest[0][0], 'a');
+        $this->assertEquals($object->nest[1][0], 'b');
+    }
+
+    public function testArrays()
+    {
+        $filename = __DIR__.'/fixtures/valid/arrays.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('ints', $object);
+        $this->assertObjectHasAttribute('floats', $object);
+        $this->assertObjectHasAttribute('strings', $object);
+        $this->assertObjectHasAttribute('dates', $object);
+
+        $this->assertEquals($object->ints[0], 1);
+        $this->assertEquals($object->ints[1], 2);
+        $this->assertEquals($object->ints[2], 3);
+
+        $this->assertEquals($object->floats[0], 1.0);
+        $this->assertEquals($object->floats[1], 2.0);
+        $this->assertEquals($object->floats[2], 3.0);
+
+        $this->assertEquals($object->strings[0], 'a');
+        $this->assertEquals($object->strings[1], 'b');
+        $this->assertEquals($object->strings[2], 'c');
+
+        $this->assertTrue($object->dates[0] instanceof \Datetime);
+        $this->assertTrue($object->dates[1] instanceof \Datetime);
+        $this->assertTrue($object->dates[2] instanceof \Datetime);
+    }
+
+    public function testBool()
+    {
+        $filename = __DIR__.'/fixtures/valid/bool.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('t', $object);
+        $this->assertObjectHasAttribute('t', $object);
+
+        $this->assertEquals($object->t, true);
+        $this->assertEquals($object->f, false);
+    }
+
+    public function testCommentsEverywhere()
+    {
+        $filename = __DIR__.'/fixtures/valid/commentsEverywhere.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('answer', $object->group);
+        $this->assertObjectHasAttribute('more', $object->group);
+
+        $this->assertEquals($object->group->answer, 42);
+        $this->assertEquals($object->group->more[0], 42);
+        $this->assertEquals($object->group->more[1], 42);
+    }
+
+    public function testDatetime()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse("bestdayever = 1987-07-05T17:45:00Z");
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('bestdayever', $object);
+
+        $this->assertTrue($object->bestdayever instanceof \Datetime);
+    }
+
+    public function testEmpty()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse("");
+
+        $this->assertNull($object);
+    }
+
+    public function testExample()
+    {
+        $filename = __DIR__.'/fixtures/valid/example.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('best-day-ever', $object);
+        $this->assertObjectHasAttribute('emptyName', $object);
+        $this->assertObjectHasAttribute('numtheory', $object);
+
+        $this->assertTrue($object->{'best-day-ever'} instanceof \Datetime);
+        $this->assertEquals("", $object->emptyName);
+        $this->assertTrue(is_object($object->numtheory));
+
+        $this->assertEquals($object->numtheory->boring, false);
+        $this->assertEquals($object->numtheory->perfection[0], 6);
+        $this->assertEquals($object->numtheory->perfection[1], 28);
+        $this->assertEquals($object->numtheory->perfection[2], 496);
+    }
+
+    public function testFloat()
+    {
+        $filename = __DIR__.'/fixtures/valid/float.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('pi', $object);
+        $this->assertObjectHasAttribute('negpi', $object);
+
+        $this->assertEquals($object->pi, 3.14);
+        $this->assertEquals($object->negpi, -3.14);
+    }
+
+    public function testImplicitAndExplicitAfter()
+    {
+        $filename = __DIR__.'/fixtures/valid/implicitAndExplicitAfter.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('a', $object);
+        $this->assertObjectHasAttribute('b', $object->a);
+        $this->assertObjectHasAttribute('c', $object->a->b);
+        $this->assertObjectHasAttribute('better', $object->a);
+
+        $this->assertEquals($object->a->b->c->answer, 42);
+        $this->assertEquals($object->a->better, 43);
+    }
+
+    public function testImplicitAndExplicitBefore()
+    {
+        $filename = __DIR__.'/fixtures/valid/implicitAndExplicitBefore.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('a', $object);
+        $this->assertObjectHasAttribute('b', $object->a);
+        $this->assertObjectHasAttribute('c', $object->a->b);
+        $this->assertObjectHasAttribute('better', $object->a);
+
+        $this->assertEquals($object->a->b->c->answer, 42);
+        $this->assertEquals($object->a->better, 43);
+    }
+
+    public function testImplicitGroups()
+    {
+        $filename = __DIR__.'/fixtures/valid/implicitGroups.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertObjectHasAttribute('a', $object);
+        $this->assertObjectHasAttribute('b', $object->a);
+        $this->assertObjectHasAttribute('c', $object->a->b);
+
+        $this->assertEquals($object->a->b->c->answer, 42);
+    }
+
+    public function testImplicitInteger()
+    {
+        $filename = __DIR__.'/fixtures/valid/integer.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->answer, 42);
+        $this->assertEquals($object->neganswer, -42);
+    }
+
+    public function testKeyEqualsNoSpace()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('answer=42');
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->answer, 42);
+    }
+
+    public function testKeySpecialChars()
+    {
+        $filename = __DIR__.'/fixtures/valid/keySpecialChars.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->{"~!@#$^&*()_+-`1234567890[]\|/?><.,;:'"}, 1);
+    }
+
+    public function testKeyWithPound()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('key#name = 5');
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->{'key#name'}, 5);
+    }
+
+    public function testTableEmpty()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('[a]');
+
+        $this->assertNotNull($object);
+
+        $this->assertTrue(is_object($object->a));
+    }
+
+    public function testTableSubEmpty()
+    {
+        $filename = __DIR__.'/fixtures/valid/tableSubEmpty.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertTrue(is_object($object->a));
+        $this->assertTrue(is_object($object->a->b));
+    }
+
+    public function testTableWhiteSpace()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('[valid key]');
+
+        $this->assertNotNull($object);
+
+        $this->assertTrue(is_object($object->{'valid key'}));
+    }
+
+    public function testTableWithPound()
+    {
+        $filename = __DIR__.'/fixtures/valid/tableWithPound.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertTrue(is_object($object->{'key#group'}));
+
+        $this->assertEquals($object->{'key#group'}->answer, 42);
+    }
+
+    public function testLongFloat()
+    {
+        $filename = __DIR__.'/fixtures/valid/longFloat.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->longpi, 3.141592653589793);
+        $this->assertEquals($object->neglongpi, -3.141592653589793);
+    }
+
+    public function testLongInteger()
+    {
+        $filename = __DIR__.'/fixtures/valid/longInteger.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertTrue($object->answer > 0);
+        $this->assertTrue($object->neganswer < 0);
+    }
+
+    public function testStringEscapes()
+    {
+        $filename = __DIR__.'/fixtures/valid/stringEscapes.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->backspace, "This string has a \b backspace character.");
+        $this->assertEquals($object->tab, "This string has a \t tab character.");
+        $this->assertEquals($object->newline, "This string has a \n new line character.");
+        $this->assertEquals($object->formfeed, "This string has a \f form feed character.");
+        $this->assertEquals($object->carriage, "This string has a \r carriage return character.");
+        $this->assertEquals($object->quote, "This string has a \" quote character.");
+        $this->assertEquals($object->slash, "This string has a / slash character.");
+        $this->assertEquals($object->backslash, "This string has a \\ backslash character.");
+    }
+
+    public function testStringSimple()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('answer = "You are not drinking enough whisky."');
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->answer, 'You are not drinking enough whisky.');
+    }
+
+    public function testStringWithPound()
+    {
+        $filename = __DIR__.'/fixtures/valid/stringWithPound.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->pound, 'We see no # comments here.');
+        $this->assertEquals($object->poundcomment, 'But there are # some comments here.');
+    }
+
+    public function testUnicodeEscape()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('answer = "\u03B4"');
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->answer, json_decode('"\u03B4"'));
+    }
+
+    public function testUnicodeLitteral()
+    {
+        $parser = new ObjectParser();
+
+        $object = $parser->parse('answer = "δ"');
+
+        $this->assertNotNull($object);
+
+        $this->assertEquals($object->answer, 'δ');
+    }
+
+    public function testTableArrayImplicit()
+    {
+        $filename = __DIR__.'/fixtures/valid/tableArrayImplicit.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+        $this->assertCount(1, get_object_vars($object));
+        $this->assertEquals('Glory Days', $object->albums->songs->name);
+    }
+
+    public function testTableArrayMany()
+    {
+        $filename = __DIR__.'/fixtures/valid/tableArrayMany.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+        $this->assertCount(1, get_object_vars($object));
+
+        $this->assertEquals('Bruce', $object->people[0]->first_name);
+        $this->assertEquals('Springsteen', $object->people[0]->last_name);
+
+        $this->assertEquals('Eric', $object->people[1]->first_name);
+        $this->assertEquals('Clapton', $object->people[1]->last_name);
+
+        $this->assertEquals('Bob', $object->people[2]->first_name);
+        $this->assertEquals('Seger', $object->people[2]->last_name);
+    }
+
+    public function testTableArrayNest()
+    {
+        $filename = __DIR__.'/fixtures/valid/tableArrayNest.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+        $this->assertCount(1, get_object_vars($object));
+
+        $this->assertEquals('Born to Run', $object->albums[0]->name);
+        $this->assertEquals('Jungleland', $object->albums[0]->songs[0]->name);
+        $this->assertEquals('Meeting Across the River', $object->albums[0]->songs[1]->name);
+
+        $this->assertEquals('Born in the USA', $object->albums[1]->name);
+        $this->assertEquals('Glory Days', $object->albums[1]->songs[0]->name);
+        $this->assertEquals('Dancing in the Dark', $object->albums[1]->songs[1]->name);
+    }
+
+    public function testTableArrayOne()
+    {
+        $filename = __DIR__.'/fixtures/valid/tableArrayOne.toml';
+
+        $parser = new ObjectParser();
+
+        $object = $parser->parse(file_get_contents($filename));
+
+        $this->assertNotNull($object);
+        $this->assertCount(1, get_object_vars($object));
+
+        $this->assertEquals('Bruce', $object->people[0]->first_name);
+        $this->assertEquals('Springsteen', $object->people[0]->last_name);
+    }
+}


### PR DESCRIPTION
I'm in the process of writing a library inspired by the JSON schema spec that is serialization-agnostic (i.e. works with JSON, YAML, or TOML). It would be extremely handy to have the option to produce `stdClass` objects similar to `json_decode`, as it removes the ambiguity between an empty array and an empty object. Generic objects can also be really nice for working with this kind of data.

In this PR, I simply copy-pasted your existing parser and tweaked it, until it produced objects instead of associative arrays. This way there's no performance sacrifice, as there would be if the original parser was modified to conditionally change its output. I also copied the test suite, and modified where necessary to suit the new parser.

I'm sure that the two parsers could also be refactored into a common base class, but I don't have the time to tackle that at the moment.

Cheers :)
