### PR TITLE
Better support for dates as specified in the latest TOML spec

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -524,7 +524,7 @@ class Parser
 
     private function isLiteralDatetime(Token $token)
     {
-        return preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|(\.\d{6})?-\d{2}:\d{2})$/', $token->getValue());
+        return preg_match('/^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(Z|(\.\d{6})?-\d{2}:\d{2}))?$/', $token->getValue());
     }
 
     private function &getLastElementRef(&$array)

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -524,7 +524,7 @@ class Parser
 
     private function isLiteralDatetime(Token $token)
     {
-        return preg_match('/^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(Z|(\.\d{6})?-\d{2}:\d{2}))?$/', $token->getValue());
+        return preg_match('/^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{6})?(Z|-\d{2}:\d{2})?)?$/', $token->getValue());
     }
 
     private function &getLastElementRef(&$array)

--- a/tests/ParserInvalidTest.php
+++ b/tests/ParserInvalidTest.php
@@ -87,16 +87,6 @@ class ParserInvalidTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Yosymfony\Toml\Exception\ParseException
      */
-    public function testDatetimeMalformedNoZ()
-    {
-        $parser = new Parser();
-
-        $array = $parser->parse('no-z = 1987-07-05T17:45:00');
-    }
-
-    /**
-     * @expectedException \Yosymfony\Toml\Exception\ParseException
-     */
     public function testDatetimeMalformedWithMilli()
     {
         $parser = new Parser();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -185,11 +185,12 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('bestdayever', $array);
         $this->assertArrayHasKey('bestdayever2', $array);
-        $this->assertArrayHasKey('bestdayever3', $array);
+        $this->assertArrayHasKey('bestdayever4', $array);
 
         $this->assertTrue($array['bestdayever'] instanceof \Datetime);
         $this->assertTrue($array['bestdayever2'] instanceof \Datetime);
         $this->assertTrue($array['bestdayever3'] instanceof \Datetime);
+        $this->assertTrue($array['bestdayever4'] instanceof \Datetime);
     }
 
     public function testEmpty()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -185,12 +185,17 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('bestdayever', $array);
         $this->assertArrayHasKey('bestdayever2', $array);
+        $this->assertArrayHasKey('bestdayever3', $array);
         $this->assertArrayHasKey('bestdayever4', $array);
+        $this->assertArrayHasKey('bestdayever5', $array);
+        $this->assertArrayHasKey('bestdayever6', $array);
 
         $this->assertTrue($array['bestdayever'] instanceof \Datetime);
         $this->assertTrue($array['bestdayever2'] instanceof \Datetime);
         $this->assertTrue($array['bestdayever3'] instanceof \Datetime);
         $this->assertTrue($array['bestdayever4'] instanceof \Datetime);
+        $this->assertTrue($array['bestdayever5'] instanceof \Datetime);
+        $this->assertTrue($array['bestdayever6'] instanceof \Datetime);
     }
 
     public function testEmpty()

--- a/tests/fixtures/valid/datetime.toml
+++ b/tests/fixtures/valid/datetime.toml
@@ -1,3 +1,4 @@
 bestdayever = 1987-07-05T17:45:00Z
 bestdayever2 = 1979-05-27T00:32:00-07:00
 bestdayever3 = 1979-05-27T00:32:00.999999-07:00
+bestdayever4 = 1979-05-27

--- a/tests/fixtures/valid/datetime.toml
+++ b/tests/fixtures/valid/datetime.toml
@@ -1,4 +1,6 @@
 bestdayever = 1987-07-05T17:45:00Z
 bestdayever2 = 1979-05-27T00:32:00-07:00
 bestdayever3 = 1979-05-27T00:32:00.999999-07:00
-bestdayever4 = 1979-05-27
+bestdayever4 = 1979-05-27T07:32:00
+bestdayever5 = 1979-05-27T00:32:00.999999
+bestdayever6 = 1979-05-27


### PR DESCRIPTION
This adds support for less specific datetimes, which was added after v0.4.0 of the spec. The feature is still not tagged in a new spec version, but it is incredibly useful.