### PR TITLE
Added a fromArray() method to convert a parsed TOML file (an array) back to a TOML file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ php:
 before_script:
   - composer self-update
   - composer install --dev --no-interaction
+
+script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - 7.0
   - hhvm
 
+matrix:
+  allow_failures:
+    - php: hhvm
+
 before_script:
   - composer self-update
   - composer install --dev --no-interaction

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ The result of this example:
         [[fruit.variety]]
         name = "platain"
 
+Write generated TOML to a file:
+```php
+$tb->saveToFile('/tmp/my.toml');
+```
+
 #### Deprecated methods
 
 * **addGroup**: since version 0.2. Replaced by `addTable`.

--- a/README.md
+++ b/README.md
@@ -166,4 +166,4 @@ You can run the unit tests with the following command:
 
     $ cd your-path/vendor/yosymfony/toml
     $ composer.phar install --dev
-    $ phpunit
+    $ vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": ">=4.8"
+    },
     "autoload": {
         "psr-4": { "Yosymfony\\Toml\\": "src/" }
     },

--- a/src/Toml.php
+++ b/src/Toml.php
@@ -40,7 +40,10 @@ class Toml
     {
         $file = '';
 
-        if (is_file($input)) {
+        // strval() && str_replace() of NULL char (\0) here to prevent weird PHP
+        // error "PHP Warning:  is_file() expects parameter 1 to be a valid
+        // path, string given".
+        if (is_file(strval(str_replace("\0", "", $input)))) {
             if (!is_readable($input)) {
                 throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $input));
             }

--- a/src/TomlBuilder.php
+++ b/src/TomlBuilder.php
@@ -45,7 +45,7 @@ class TomlBuilder
      * @param array $data An array of data to build a TOML file from.
      * @param int $indent The amount of spaces to use for indentation of nested nodes.
      */
-    public function __construct(array $data = [], $indent = 4)
+    public function __construct(array $data = array(), $indent = 4)
     {
         $this->prefix = $indent ? str_repeat(' ', $indent) : '';
         if (!empty($data)) {

--- a/src/TomlBuilder.php
+++ b/src/TomlBuilder.php
@@ -42,11 +42,15 @@ class TomlBuilder
     /**
      * Constructor.
      *
+     * @param array $data An array of data to build a TOML file from.
      * @param int $indent The amount of spaces to use for indentation of nested nodes.
      */
-    public function __constructor($indent = 4)
+    public function __construct(array $data = [], $indent = 4)
     {
         $this->prefix = $indent ? str_repeat(' ', $indent) : '';
+        if (!empty($data)) {
+            $this->fromArray($data);
+        }
     }
 
     /**

--- a/src/TomlBuilder.php
+++ b/src/TomlBuilder.php
@@ -522,7 +522,6 @@ class TomlBuilder
             "\f" => '\\f',
             "\r" => '\\r',
             '"' => '\\"',
-            '/' => '\\/',
         );
 
         $normalized = str_replace(array_keys($allowed), $allowed, $val);

--- a/src/TomlBuilder.php
+++ b/src/TomlBuilder.php
@@ -197,6 +197,32 @@ class TomlBuilder
     }
 
     /**
+     * Write a Toml file.
+     *
+     * @param $filePath
+     *
+     * @throws DumpException
+     */
+    public function saveToFile($filePath)
+    {
+        $handle = @fopen($filePath, 'w');
+        if ($handle === false) {
+            throw new DumpException(sprintf('Cannot open file "%s" for writing.', $filePath));
+        }
+
+        $bytesWritten = @fwrite($handle, $this->getTomlString());
+        if ($bytesWritten === false) {
+            fclose($handle);
+            throw new DumpException(sprintf('Cannot write to file "%s".', $filePath));
+        }
+
+        $closed = @fclose($handle);
+        if ($closed === false) {
+            throw new DumpException(sprintf('Cannot close file handle for "%s".', $filePath));
+        }
+    }
+
+    /**
      * Build toml file from given array.
      *
      * @param array $data

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -11,10 +11,10 @@
 
 namespace Yosymfony\Toml\tests;
 
+use PHPUnit\Framework\TestCase;
 use Yosymfony\Toml\Lexer;
-use Yosymfony\Toml\Token;
 
-class LexerTest extends \PHPUnit_Framework_TestCase
+class LexerTest extends TestCase
 {
     public function testGetToken()
     {

--- a/tests/ParserInvalidTest.php
+++ b/tests/ParserInvalidTest.php
@@ -11,8 +11,8 @@
 
 namespace Yosymfony\Toml\tests;
 
+use PHPUnit\Framework\TestCase;
 use Yosymfony\Toml\Parser;
-use Yosymfony\Toml\Toml;
 
 /*
  * Tests based on toml-test from BurntSushi
@@ -21,7 +21,7 @@ use Yosymfony\Toml\Toml;
 
  * @see https://github.com/BurntSushi/toml-test/tree/master/tests/invalid
  */
-class ParserInvalidTest extends \PHPUnit_Framework_TestCase
+class ParserInvalidTest extends TestCase
 {
     /**
      * @expectedException \Yosymfony\Toml\Exception\ParseException

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -11,8 +11,8 @@
 
 namespace Yosymfony\Toml\tests;
 
+use PHPUnit\Framework\TestCase;
 use Yosymfony\Toml\Parser;
-use Yosymfony\Toml\Toml;
 
 /*
  * Tests based on toml-test from BurntSushi
@@ -21,7 +21,7 @@ use Yosymfony\Toml\Toml;
 
  * @see https://github.com/BurntSushi/toml-test/tree/master/tests/valid
  */
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     public function testArrayEmpty()
     {

--- a/tests/TomlBuilderInvalidTest.php
+++ b/tests/TomlBuilderInvalidTest.php
@@ -11,9 +11,10 @@
 
 namespace Yosymfony\Toml\tests;
 
+use PHPUnit\Framework\TestCase;
 use Yosymfony\Toml\TomlBuilder;
 
-class TomlBuilderInvalidTest extends \PHPUnit_Framework_TestCase
+class TomlBuilderInvalidTest extends TestCase
 {
     /**
      * @expectedException \Yosymfony\Toml\Exception\DumpException

--- a/tests/TomlBuilderTest.php
+++ b/tests/TomlBuilderTest.php
@@ -11,10 +11,11 @@
 
 namespace Yosymfony\Toml\tests;
 
+use PHPUnit\Framework\TestCase;
 use Yosymfony\Toml\TomlBuilder;
 use Yosymfony\Toml\Toml;
 
-class TomlBuilderTest extends \PHPUnit_Framework_TestCase
+class TomlBuilderTest extends TestCase
 {
     public function testExample()
     {

--- a/tests/TomlTest.php
+++ b/tests/TomlTest.php
@@ -11,9 +11,10 @@
 
 namespace Yosymfony\Toml\tests;
 
+use PHPUnit\Framework\TestCase;
 use Yosymfony\Toml\Toml;
 
-class TomlTest extends \PHPUnit_Framework_TestCase
+class TomlTest extends TestCase
 {
     public function testFile()
     {


### PR DESCRIPTION
The biggest thing I'm missing in this library is to 'edit' TOML files:

1. Load in a TOML file
2. Make changes
3. Write back to TOML file.

For this purpose I've added an additional method `fromArray()` on the TomlBuilder class to allow just this. I must say I'm not very pleased with it, but it does the job.
A better way would be to parse a file to an object oriented representation to allow easy manipulation (with some helper methods) and write that OO version back to a file.
**I've tried to do this, but I cannot really grasp how this library does it's magic so I failed miserably...**

Example use:
```php
// Parse file to array:
$array = \Yosymfony\Toml\Toml::parse('/my/config.toml');

// Modify $array where needed...

// Build new file from the above array:
$tb = new \Yosymfony\Toml\TomlBuilder();
$tb->fromArray($array);
// View the toml string.
echo $tb->getTomlString();
```
**Edit:** Forgot to mention that at some point I bumped into this one #12.
**Edit2:** I'm not sure how to write a proper test for this though: grab a file, parse it, use the fromArray() method followed by `getTomlString()` and parse that 'new' string to an array and compare it with the original array?