### PR TITLE
AOT and Table nesting complexity

### DIFF
--- a/Informal-TOML-part-specifications.md
+++ b/Informal-TOML-part-specifications.md
@@ -1,0 +1,238 @@
+
+TOML is Obvious, More or Less
+====
+
+TOML may be Tom's obvious markup language, but there are some features of implementing readers and writers for TOML configuration files, that are less obvious, at least in the 0.4 Toml Specification, here at https://github.com/toml-lang/toml/blob/master/README.md. To give this version and obvious abbreviation, lets call it TOM04. From an implementer perspective, which I've now began to experience, there are some subtle details coming to light. 
+
+Because its so obvious, I will be repeating stuff that is well described and even assumed by the TOM04 documents.
+
+TOM04 has some good working implementations
+-----
+
+Quite a few implementations already exist in a number of programming languages, so its possible to easily construct a make-do simple implementation that caters a fair range of particular text-configurations, and this has been done for earlier version specifications as well. For instance the Rust programming language and its "cargo" tool uses TOML configuration files for project management. I'm sure they have done a thorough job. Many other languages are said to have 'compliant' implementations, as listed on the official wiki page at https://github.com/toml-lang/toml/wiki.
+
+TOM04 needs more test examples that are useful for software conformance testing
+-----
+In so many ways, the sets of "valid" and "invalid" test examples to run through TOML parsers, and their documented output structures, in whatever language, are the real TOM04 specification, as is for XML and other data formatting specifications. Having reference test documents and reference implementations that are able to read them do strongly indicate that the specification is reasonably self-consistant.  The actual TOM04 github site hasn't got that many full document examples. Where they exist, as in the tricky AOT - table example below, there isn't even a comment to say 'valid' or 'invalid'.
+Their is some collective wisdom amoung the many bits of TOML descriptions and example fragments in sepecification, which is a README.md document, even as they set up these collective puzzles.
+
+
+Array of Tables with [[All.Of.Me.Is.AOT]] seems very under specified.
+-----
+
+TOM04 distinguishes between "arrays" and "tables",  which are typical sorts of general use containers for values, typically used as internal data structures in computer programs. Tables aren't multi-column things, they always only 2  column things, the first being a key, and the second being the value. Key and value are seperated by the equals sign, which acts as the "column" divider. In TOML, the newline seperates the table rows.
+
+TOML documents are read in the top to bottom, right to left on the page fashion. In the text document in the computer file, this is a just sequence of bytes, and 1 or 2 bytes conventionally encode the end of each line.
+File text encodings are most likely to be ASCII text, or UTF-8, regardless of which byte(s) signify end of line.
+
+Decoding, and normalizing the end of line markers, is usually a pre-parse step, although it can be done with streamming on the fly.  Proper use of Byte-Order-Mark conventions at the beginning of a file are essential for none-ASCII and none-UTF-8 data files conversions.
+
+The innovation of TOM04 is to use the section headers of INI format as a definitive key path, to specify the location in a structure or document, for its subsequent key-values.
+
+
+AOT technical intentions vs human intentions
+------
+Here is a tricky case from the TOML examples
+```toml
+[[fruit.blah]]
+  name = "apple"
+
+  [fruit.blah.physical]
+    color = "red"
+    shape = "round"
+
+[[fruit.blah]]
+  name = "banana"
+
+  [fruit.blah.physical]
+    color = "yellow"
+    shape = "bent"
+```
+Its even more tricky because there are no comments directly written into the text document with this example, to say how it should be handled, so I have to read the specification, and look for similar cases, on the same site. It is kind of unfair, for a site that supposedly sets the standard. I am probably missing out on all the discussion back-channels.
+
+The naive parsing of tables, just ignores what ever has gone before, and says here is a table, key-path "fruit.bar.physical".  Where do I want it to go? In key path 'fruit.blah.physical', exactly that, from the root.
+
+So what examples are on the TOML spec that tell us about a shared key path of a table with most recent preceding AOT?
+
+After all, [table] and key-value pairs share the same key namespace, and the AOT before it, has just established a "key name space" of 'fruit.0.blash.0', and all subsequent key=value pairs are said to be in that name space.
+
+But table names are fully specified. If I want a table called 'physical' inside the current 'blah' leaf, I cannot do it by specifying 'physical', because that is an entirely new unshared, singular subroot. Here is what I think a test case should produce, from the above toml document. Its in my first comment from my fork, in the branch called 'nearyou', as the only change.  Of course its in my 'mrynn' branch commits which need both the parse-utils and toml repository forks, there are dependent changes in both.  
+
+In more recent versions of php '[' is the same as 'array(' and ')' is the same as the functions closing bracket. They are identical, they produce the same 'byte code'.
+
+```php
+'fruit' => [
+    [
+        'blah' => [
+            [
+                'name' => 'apple',
+                'physical' => [
+                    'color' => "red",
+                    'shape' => "round",
+                ],
+            ],
+            [
+                'name' => 'banana',
+                'physical' => [
+                    'color' => "yellow",
+                    'shape' => "bent",
+                ],
+            ]
+        ]
+    ],
+]
+```
+
+The PHP '[-]' notation is equivalent and compatible with the older notation, in which 'array' is the name of a function, and its argument is text to be interpreted according to what has been interpreted already.  
+
+```php
+$mybigarray = array(
+'fruit' => [
+]
+);
+```
+
+TOML is the same. Its a series of function calls which interpret the text and build up internal state.
+The specification page gives an example to suggest what is the TOML interpretation , by giving us the equivalent expected JSON structure.
+
+"You can create nested arrays of tables as well. Just use the same double bracket syntax on sub-tables. Each double-bracketed sub-table will belong to the most recently defined table element above it."
+
+Here is their cut-and-pasted tom example. The example (not the words) also shows that single bracketed sub-table belongs to the most recently defined table element of the AOT (ie the 0-indexed first table in 'fruit' AOT)
+
+```toml
+[[fruit]]
+  name = "apple"
+
+  [fruit.physical]
+    color = "red"
+    shape = "round"
+
+  [[fruit.variety]]
+    name = "red delicious"
+
+  [[fruit.variety]]
+    name = "granny smith"
+
+[[fruit]]
+  name = "banana"
+
+  [[fruit.variety]]
+    name = "plantain"
+```
+Here spec JSON structure interpretation from the official TOML spec. [fruit.physical] goes into the zero'th table member of the AOT defined by [[fruit]], as does the AOT defined by [[fruit.variety]].
+
+This behaviour can't be implemented with naive, AOT context free, table creation. Here it is.
+
+```json
+{
+  "fruit": [
+    {
+      "name": "apple",
+      "physical": {
+        "color": "red",
+        "shape": "round"
+      },
+      "variety": [
+        { "name": "red delicious" },
+        { "name": "granny smith" }
+      ]
+    },
+    {
+      "name": "banana",
+      "variety": [
+        { "name": "plantain" }
+      ]
+    }
+  ]
+}
+```
+
+My first naive way around this, was to take the term 'most recently defined' table element literally, (defined by key-paths without the implicit numeric index of tables) and think in terms of remembering most recent contexts. I then made a stacked object to remember the most recent nesting case, which negotiated the above tricksy case. 
+
+But then I thought, what if I imposed a completedly different keypath table, with different root name, in-between any of these 'fruit' example sections. Does this change the relationships? It would most likely wipe out my temporary stacked items. But it by no means changes the relationships and order of the 'fruit' specific data. Therefore, to implement this, I have to concentrate on the key path relationships, between AOT and other AOT and tables, and the current AOT table instances that are implied, and maintain enough information about each AOT.  I don't need table instance information to be stored in quite the same way. 
+
+"Each double-bracketed sub-table will belong to the most recently defined table element above it", isn't quite so obvious, because of the implicit arrays of tables.
+
+I will try here to say what I think the TOML spec should publish and make clear, and how to make AOT declarations more explicit.
+
+Table context depends on the order of shared path relatioships.  If the table came first, before the AOT, it is obviously a different structure altogether, as the table sets up a simple, naive table key path.
+
+Have some not quite so simple alternatives been suggested for table path notation?
+------
+ AOT establish a key path, that to the human reader, and config file writer, is overtly, without the numeric indexes. A double brackets means the virtual path formed by the latest AOT member definitions. Its always going to be that [[AOTRoot.NextLevel]] actually means [AOTRoot[].NextLevel[]] Here I use the "[]" to mean that the key points to an array of tables. The default for a normal table [AOTRoot.NextLevel]  means [AOTRoot{}.NextLevel{}]
+ 
+The JSON representation 
+```JSON
+{
+"AOTRoot" : [
+	{
+	"NextLevel" : [
+		{}, {}, 
+	]
+	}, 
+	{}, {}
+	]
+```
+
+What TOML seems out is a way of specifying this JSON representation, where array of tables appear as children of ordinary tables.
+
+```JSON
+{
+"AOTRoot" : 
+	{
+		"NextLevel" : [
+		{}, {}, 
+	]
+	}
+```
+Here the value of key 'AOTRoot' is a singular table, not an Array of Tables. The array brackets, and addition empty tables have been removed. How might we declare this in TOML, while remaining compatible with TOM04?
+
+If it has not already been suggested or formally proposed, the following table declaration syntax rules would be compatible with current AOT specification. 
+
+Array of Tables declaration can be a single brackets enclosed path, using [AOTName[].NextLevel] 
+A simple table with an array of tables key value is then [RootTable.AOTTable[]], or more explicitly [RootTable{}.AOTTable[]].
+
+Best, most general table path syntax?
+--------------
+Another syntax possible is to build on the nested brackets idea. It is possible enclose kust the array of table levels in brackets, as in the path description [RootTable.[NextLevel].JustATable], or [RootTable.JustATable.[ArrayOfTables]] and even [RootTable.[MiddleAOT.EndAOT].LeafTable].  This is a more general formulation of the current all encompassing  [[Everything.Inside.Here.Is.AOTable]] idea.
+
+To me this seems simple and obvious enough. TOML does aim for general JSON structure representation equivalence without all the rigidity, fuss, and lack of anywhere to put comments.
+
+Because the above example on the TOML site is very specific and clear, I now distrust all those so called compliant software packages for the various programming languages and libraries, since maybe they may don't implement this sublte feature correctly. I haven't tried any of them yet, other than the two PHP versions that appear on a google search. 
+(Other than Yosymphony, there was another PHP candidate that I was using initially, and it was works pretty well, and it claimed TOM04 compliance, until I started to notice it didn't convert integer keys into strings. The Yosymfony version appears to have been built with better test and design discipline, with the use of phpunit testing framework. I played enough with the other at (https://github.com/leonelquinteros/php-toml), to find out that TOM04 is good to use.
+Its possible that TOM04 doesn't actually do AOT contexts, and this is a new feature that has been added later, that will be more fully and generally specified in 1.0, whenever this is published.  The TOM04 readme is insufficient on these details.
+
+So the new TOML seems to be begging to come up with this sort of rule : -
+
+A [table] or AOT that shares any part of a previously declared AOT path, and is an implicit nested child, by the main key components, is nested in the context of that shared path using the current last table members of the shared parts of the AOT path.
+
+The problem now, is my more specific definition of AOT in a table path, could make the above [[fruit]] example illegal. We need an extra brackets around the 'fruit' in [fruit.physical] to make it good, as done below.
+```toml
+[[fruit]]
+  name = "apple"
+
+  [[fruit].physical]
+    color = "red"
+    shape = "round"
+
+  [[fruit.variety]]
+    name = "red delicious"
+
+  [[fruit.variety]]
+    name = "granny smith"
+
+[[fruit]]
+  name = "banana"
+
+  [[fruit.variety]]
+    name = "plantain"
+```
+
+Or a rule could be made, or restated in this form, that if [[fruit]] has declared directly or implicitly that fruit is a direct key to an AOT structure, any further use of fruit in that key path also implies the same, wether or not extra square brackets are used subsequent declarations around the parth part 'fruit'. The TOM04 example seems to imply just this idea.
+In a statically typed, compile language, the array object is created and can't be changed.
+If 'fruit' is first used without extra square brackets, then it is illegal to put extra square brackets around it in a later declaration.
+
+To be a complete specification, the table path [[fruit].[variety]] must be equivalent to [[fruit.variety]].
+and to be really specific or annoying we could put braces around table path parts,  such as [[fruit].{physical}], or say that no brackets implies curly braces.
+
+

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -24,39 +24,95 @@ class Lexer implements LexerInterface
 {
     private $basicLexer;
 
+     const T_EQUAL = 1;
+     const T_BOOLEAN = 2;
+     const T_DATE_TIME = 3;
+     const T_EOS = 4;
+     const T_INTEGER = 5;
+     const T_3_QUOTATION_MARK = 6;
+     const T_QUOTATION_MARK = 7;
+     const T_3_APOSTROPHE = 8;
+     const T_APOSTROPHE = 9;
+     const T_NEWLINE = 10;
+     const T_SPACE = 11;
+     const T_LEFT_SQUARE_BRAKET = 12;
+     const T_RIGHT_SQUARE_BRAKET = 13;
+     const T_LEFT_CURLY_BRACE = 14;
+     const T_RIGHT_CURLY_BRACE = 15;
+     const T_COMMA = 16;
+     const T_DOT = 17;
+     const T_UNQUOTED_KEY = 18;
+     const T_ESCAPED_CHARACTER = 19;
+     const T_ESCAPE = 20;
+     const T_BASIC_UNESCAPED = 21;
+     const T_FLOAT = 22;
+     const T_HASH = 23;
+     const T_LAST_TOKEN = 23;
+    
+     
+     static private $nameSet = [
+         'T_BAD_TOKEN', //0
+         'T_EQUAL',//1
+         'T_BOOLEAN',//2
+         'T_DATE_TIME',//3
+         'T_EOS',//4
+         'T_INTEGER',//5
+         'T_3_QUOTATION_MARK',//6
+         'T_QUOTATION_MARK',//7
+         'T_3_APOSTROPHE',//8
+         'T_APOSTROPHE',//9
+         'T_NEWLINE',//10
+         'T_SPACE',//11
+         'T_LEFT_SQUARE_BRAKET',//12
+         'T_RIGHT_SQUARE_BRAKET',//13
+         'T_LEFT_CURLY_BRACE',//14
+         'T_RIGHT_CURLY_BRACE',//15
+         'T_COMMA',//16
+         'T_DOT',//17
+         'T_UNQUOTED_KEY',//18
+         'T_ESCAPED_CHARACTER',//19
+         'T_ESCAPE',//20
+         'T_BASIC_UNESCAPED',//21
+         'T_FLOAT',//22
+         'T_HASH',//23
+     ];
+
     /**
      * Constructor
      */
     public function __construct()
     {
         $this->basicLexer = new BasicLexer([
-            '/^(=)/' => 'T_EQUAL',
-            '/^(true|false)/' => 'T_BOOLEAN',
-            '/^(\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{6})?(Z|-\d{2}:\d{2})?)?)/' => 'T_DATE_TIME',
-            '/^([+-]?((((\d_?)+[\.]?(\d_?)*)[eE][+-]?(\d_?)+)|((\d_?)+[\.](\d_?)+)))/' => 'T_FLOAT',
-            '/^([+-]?(\d_?)+)/' => 'T_INTEGER',
-            '/^(""")/' => 'T_3_QUOTATION_MARK',
-            '/^(")/' => 'T_QUOTATION_MARK',
-            "/^(''')/" => 'T_3_APOSTROPHE',
-            "/^(')/" => 'T_APOSTROPHE',
-            '/^(#)/' => 'T_HASH',
-            '/^(\s+)/' => 'T_SPACE',
-            '/^(\[)/' => 'T_LEFT_SQUARE_BRAKET',
-            '/^(\])/' => 'T_RIGHT_SQUARE_BRAKET',
-            '/^(\{)/' => 'T_LEFT_CURLY_BRACE',
-            '/^(\})/' => 'T_RIGHT_CURLY_BRACE',
-            '/^(,)/' => 'T_COMMA',
-            '/^(\.)/' => 'T_DOT',
-            '/^([-A-Z_a-z0-9]+)/' => 'T_UNQUOTED_KEY',
-            '/^(\\\(b|t|n|f|r|"|\\\\|u[0-9AaBbCcDdEeFf]{4,4}|U[0-9AaBbCcDdEeFf]{8,8}))/' => 'T_ESCAPED_CHARACTER',
-            '/^(\\\)/' => 'T_ESCAPE',
-            '/^([\x{20}-\x{21}\x{23}-\x{26}\x{28}-\x{5A}\x{5E}-\x{10FFFF}]+)/u' => 'T_BASIC_UNESCAPED',
+            '/^(=)/' => Lexer::T_EQUAL,
+            '/^(true|false)/' => Lexer::T_BOOLEAN,
+            '/^(\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{6})?(Z|-\d{2}:\d{2})?)?)/' => Lexer::T_DATE_TIME,
+            '/^([+-]?((((\d_?)+[\.]?(\d_?)*)[eE][+-]?(\d_?)+)|((\d_?)+[\.](\d_?)+)))/' => Lexer::T_FLOAT,
+            '/^([+-]?(\d_?)+)/' => Lexer::T_INTEGER,
+            '/^(""")/' => Lexer::T_3_QUOTATION_MARK,
+            '/^(")/' => Lexer::T_QUOTATION_MARK,
+            "/^(''')/" => Lexer::T_3_APOSTROPHE,
+            "/^(')/" => Lexer::T_APOSTROPHE,
+            '/^(#)/' => Lexer::T_HASH,
+            '/^(\s+)/' => Lexer::T_SPACE,
+            '/^(\[)/' => Lexer::T_LEFT_SQUARE_BRAKET,
+            '/^(\])/' => Lexer::T_RIGHT_SQUARE_BRAKET,
+            '/^(\{)/' => Lexer::T_LEFT_CURLY_BRACE,
+            '/^(\})/' => Lexer::T_RIGHT_CURLY_BRACE,
+            '/^(,)/' => Lexer::T_COMMA,
+            '/^(\.)/' => Lexer::T_DOT,
+            '/^([-A-Z_a-z0-9]+)/' => Lexer::T_UNQUOTED_KEY,
+            '/^(\\\(b|t|n|f|r|"|\\\\|u[0-9AaBbCcDdEeFf]{4,4}|U[0-9AaBbCcDdEeFf]{8,8}))/' => Lexer::T_ESCAPED_CHARACTER,
+            '/^(\\\)/' => Lexer::T_ESCAPE,
+            '/^([\x{20}-\x{21}\x{23}-\x{26}\x{28}-\x{5A}\x{5E}-\x{10FFFF}]+)/u' => Lexer::T_BASIC_UNESCAPED,
 
         ]);
 
         $this->basicLexer
             ->generateNewlineTokens()
             ->generateEosToken();
+        
+        $this->basicLexer->setNewlineTokenName(Lexer::tokenName(Lexer::T_NEWLINE), Lexer::T_NEWLINE);
+        $this->basicLexer->setEosTokenName(Lexer::tokenName(Lexer::T_EOS), Lexer::T_EOS);
     }
 
     /**
@@ -65,5 +121,12 @@ class Lexer implements LexerInterface
     public function tokenize(string $input) : TokenStream
     {
         return $this->basicLexer->tokenize($input);
+    }
+    
+    static public function tokenName(int $tokenId) : string {
+        if ($tokenId > Lexer::T_LAST_TOKEN || $tokenId < 0) {
+            $tokenId = 0;
+        }
+        return self::$nameSet[$tokenId];
     }
 }

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -27,203 +27,203 @@ class LexerTest extends TestCase
     {
         $ts = $this->lexer->tokenize('=');
 
-        $this->assertTrue($ts->isNext('T_EQUAL'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_EQUAL);
     }
 
     public function testTokenizeMustRecognizeBooleanTokenWhenThereIsATrueValue()
     {
         $ts = $this->lexer->tokenize('true');
 
-        $this->assertTrue($ts->isNext('T_BOOLEAN'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_BOOLEAN);
     }
 
     public function testTokenizeMustRecognizeBooleanTokenWhenThereIsAFalseValue()
     {
         $ts = $this->lexer->tokenize('false');
 
-        $this->assertTrue($ts->isNext('T_BOOLEAN'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_BOOLEAN);
     }
 
     public function testTokenizeMustRecognizeUnquotedKeyToken()
     {
         $ts = $this->lexer->tokenize('title');
 
-        $this->assertTrue($ts->isNext('T_UNQUOTED_KEY'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_UNQUOTED_KEY);
     }
 
     public function testTokenizeMustRecognizeIntegerTokenWhenThereIsAPositiveNumber()
     {
         $ts = $this->lexer->tokenize('25');
 
-        $this->assertTrue($ts->isNext('T_INTEGER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_INTEGER);
     }
 
     public function testTokenizeMustRecognizeIntegerTokenWhenThereIsANegativeNumber()
     {
         $ts = $this->lexer->tokenize('-25');
 
-        $this->assertTrue($ts->isNext('T_INTEGER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_INTEGER);
     }
 
     public function testTokenizeMustRecognizeIntegerTokenWhenThereIsNumberWithUnderscoreSeparator()
     {
         $ts = $this->lexer->tokenize('2_5');
 
-        $this->assertTrue($ts->isNext('T_INTEGER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_INTEGER);
     }
 
     public function testTokenizeMustRecognizeFloatTokenWhenThereIsAFloatNumber()
     {
         $ts = $this->lexer->tokenize('2.5');
 
-        $this->assertTrue($ts->isNext('T_FLOAT'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_FLOAT);
     }
 
     public function testTokenizeMustRecognizeFloatTokenWhenThereIsAFloatNumberWithUnderscoreSeparator()
     {
         $ts = $this->lexer->tokenize('9_224_617.445_991_228_313');
 
-        $this->assertTrue($ts->isNext('T_FLOAT'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_FLOAT);
     }
 
     public function testTokenizeMustRecognizeFloatTokenWhenThereIsANegativeFloatNumber()
     {
         $ts = $this->lexer->tokenize('-2.5');
 
-        $this->assertTrue($ts->isNext('T_FLOAT'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_FLOAT);
     }
 
     public function testTokenizeMustRecognizeFloatTokenWhenThereIsANumberWithExponent()
     {
         $ts = $this->lexer->tokenize('5e+22');
 
-        $this->assertTrue($ts->isNext('T_FLOAT'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_FLOAT);
     }
 
     public function testTokenizeMustRecognizeFloatTokenWhenThereIsANumberWithExponentAndUnderscoreSeparator()
     {
         $ts = $this->lexer->tokenize('1e1_000');
 
-        $this->assertTrue($ts->isNext('T_FLOAT'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_FLOAT);
     }
 
     public function testTokenizeMustRecognizeFloatTokenWhenThereIsAFloatNumberWithExponent()
     {
         $ts = $this->lexer->tokenize('6.626e-34');
 
-        $this->assertTrue($ts->isNext('T_FLOAT'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_FLOAT);
     }
 
     public function testTokenizeMustRecognizeDataTimeTokenWhenThereIsRfc3339Datetime()
     {
         $ts = $this->lexer->tokenize('1979-05-27T07:32:00Z');
 
-        $this->assertTrue($ts->isNext('T_DATE_TIME'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_DATE_TIME);
     }
 
     public function testTokenizeMustRecognizeDataTimeTokenWhenThereIsRfc3339DatetimeWithOffset()
     {
         $ts = $this->lexer->tokenize('1979-05-27T00:32:00-07:00');
 
-        $this->assertTrue($ts->isNext('T_DATE_TIME'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_DATE_TIME);
     }
 
     public function testTokenizeMustRecognizeDataTimeTokenWhenThereIsRfc3339DatetimeWithOffsetSecondFraction()
     {
         $ts = $this->lexer->tokenize('1979-05-27T00:32:00.999999-07:00');
 
-        $this->assertTrue($ts->isNext('T_DATE_TIME'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_DATE_TIME);
     }
 
     public function testTokenizeMustRecognizeQuotationMark()
     {
         $ts = $this->lexer->tokenize('"');
 
-        $this->assertTrue($ts->isNext('T_QUOTATION_MARK'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_QUOTATION_MARK);
     }
 
     public function testTokenizeMustRecognize3QuotationMark()
     {
         $ts = $this->lexer->tokenize('"""');
 
-        $this->assertTrue($ts->isNextSequence(['T_3_QUOTATION_MARK', 'T_EOS']));
+        $this->assertTrue($ts->isNextSequence([Lexer::T_3_QUOTATION_MARK, Lexer::T_EOS]));
     }
 
     public function testTokenizeMustRecognizeApostrophe()
     {
         $ts = $this->lexer->tokenize("'");
 
-        $this->assertTrue($ts->isNext('T_APOSTROPHE'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_APOSTROPHE);
     }
 
     public function testTokenizeMustRecognize3Apostrophe()
     {
         $ts = $this->lexer->tokenize("'''");
 
-        $this->assertTrue($ts->isNext('T_3_APOSTROPHE'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_3_APOSTROPHE);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsBackspace()
     {
         $ts = $this->lexer->tokenize('\b');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsTab()
     {
         $ts = $this->lexer->tokenize('\t');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsLinefeed()
     {
         $ts = $this->lexer->tokenize('\n');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsFormfeed()
     {
         $ts = $this->lexer->tokenize('\f');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsCarriageReturn()
     {
         $ts = $this->lexer->tokenize('\r');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsQuote()
     {
         $ts = $this->lexer->tokenize('\"');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsBackslash()
     {
         $ts = $this->lexer->tokenize('\\\\');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsUnicodeUsingFourCharacters()
     {
         $ts = $this->lexer->tokenize('\u00E9');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeEscapedCharacterWhenThereIsUnicodeUsingEightCharacters()
     {
         $ts = $this->lexer->tokenize('\U00E90000');
 
-        $this->assertTrue($ts->isNext('T_ESCAPED_CHARACTER'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_ESCAPED_CHARACTER);
     }
 
     public function testTokenizeMustRecognizeBasicUnescapedString()
@@ -231,8 +231,8 @@ class LexerTest extends TestCase
         $ts = $this->lexer->tokenize('@text');
 
         $this->assertTrue($ts->isNextSequence([
-            'T_BASIC_UNESCAPED',
-            'T_EOS'
+            Lexer::T_BASIC_UNESCAPED,
+            Lexer::T_EOS
         ]));
     }
 
@@ -240,14 +240,14 @@ class LexerTest extends TestCase
     {
         $ts = $this->lexer->tokenize('#');
 
-        $this->assertTrue($ts->isNext('T_HASH'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_HASH);
     }
 
     public function testTokenizeMustRecognizeEscape()
     {
         $ts = $this->lexer->tokenize('\\');
 
-        $this->assertTrue($ts->isNextSequence(['T_ESCAPE', 'T_EOS']));
+        $this->assertTrue($ts->isNextSequence([Lexer::T_ESCAPE, Lexer::T_EOS]));
     }
 
     public function testTokenizeMustRecognizeEscapeAndEscapedCharacter()
@@ -255,10 +255,10 @@ class LexerTest extends TestCase
         $ts = $this->lexer->tokenize('\\ \b');
 
         $this->assertTrue($ts->isNextSequence([
-            'T_ESCAPE',
-            'T_SPACE',
-            'T_ESCAPED_CHARACTER',
-            'T_EOS'
+            Lexer::T_ESCAPE,
+            Lexer::T_SPACE,
+            Lexer::T_ESCAPED_CHARACTER,
+            Lexer::T_EOS
         ]));
     }
 
@@ -266,34 +266,34 @@ class LexerTest extends TestCase
     {
         $ts = $this->lexer->tokenize('[');
 
-        $this->assertTrue($ts->isNext('T_LEFT_SQUARE_BRAKET'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_LEFT_SQUARE_BRAKET);
     }
 
     public function testTokenizeMustRecognizeRightSquareBraket()
     {
         $ts = $this->lexer->tokenize(']');
 
-        $this->assertTrue($ts->isNext('T_RIGHT_SQUARE_BRAKET'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_RIGHT_SQUARE_BRAKET);
     }
 
     public function testTokenizeMustRecognizeDot()
     {
         $ts = $this->lexer->tokenize('.');
 
-        $this->assertTrue($ts->isNext('T_DOT'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_DOT);
     }
 
     public function testTokenizeMustRecognizeLeftCurlyBrace()
     {
         $ts = $this->lexer->tokenize('{');
 
-        $this->assertTrue($ts->isNext('T_LEFT_CURLY_BRACE'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_LEFT_CURLY_BRACE);
     }
 
     public function testTokenizeMustRecognizeRightCurlyBrace()
     {
         $ts = $this->lexer->tokenize('}');
 
-        $this->assertTrue($ts->isNext('T_RIGHT_CURLY_BRACE'));
+        $this->assertTrue($ts->peekNext() === Lexer::T_RIGHT_CURLY_BRACE);
     }
 }

--- a/tests/ParserInvalidTest.php
+++ b/tests/ParserInvalidTest.php
@@ -71,8 +71,10 @@ toml;
     }
 
     /**
+     * TOM04 spaces around '.' can be ignored, therefore space after a key name
+     * isn't a problem, the problem is the first wrong character, the '='
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_SPACE" at line 1
+     * @expectedExceptionMessage Unexpected '=' in path, Line 1
      */
     public function testParseMustFailWhenKeyOpenBracket()
     {
@@ -96,15 +98,16 @@ toml;
     {
         $this->parser->parse('a b = 1');
     }
-
-    /**
+    /** TOM04 - White space around . is ignored, best practice is no white space, but
+     * the fail problem is the '='
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_SPACE" at line 2 with value " ".
+     * @expectedExceptionMessage Unexpected '=' in path, Line 2
      */
     public function testParseMustFailWhenKeyStartBracket()
     {
         $this->parser->parse("[a]\n[xyz = 5\n[b]");
     }
+
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
@@ -399,7 +402,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage The key "a" has already been defined previously.
+     * @expectedExceptionMessage Table path [a] at line 2 interferes with path at line 1
      */
     public function testParseMustFailWhenDuplicateTable()
     {
@@ -413,7 +416,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_RIGHT_SQUARE_BRAKET" at line 1 with value "]".
+     * @expectedExceptionMessage Path cannot be empty, Line 1
      */
     public function testParseMustFailWhenTableEmpty()
     {
@@ -421,8 +424,9 @@ toml;
     }
 
     /**
+     * TOM04 - expected a dot
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_SPACE" at line 1 with value " ".
+     * @expectedExceptionMessage Expected a '.' after path key, Line 1
      */
     public function testParseMustFailWhenTableWhitespace()
     {
@@ -431,7 +435,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_DOT" at line 1 with value ".".
+     * @expectedExceptionMessage Found '..' in path, Line 1
      */
     public function testParseMustFailWhenEmptyImplicitTable()
     {
@@ -440,7 +444,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_HASH" at line 1 with value "#".
+     * @expectedExceptionMessage Unexpected '#' in path, Line 1
      */
     public function testParseMustFailWhenTableWithPound()
     {
@@ -458,7 +462,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_LEFT_SQUARE_BRAKET" at line 1 with value "[".
+     * @expectedExceptionMessage Expected a '.' after path key, Line 1
      */
     public function testParseMustFailWhenTableNestedBracketsOpen()
     {
@@ -500,7 +504,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage The key "fruit.variety" has already been defined previously.
+     * @expectedExceptionMessage Table path [fruit.variety] at line 8 interferes with path at line 4
      */
     public function testParseMustFailWhenTableArrayWithSomeNameOfTable()
     {
@@ -521,7 +525,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_RIGHT_SQUARE_BRAKET" at line 1 with value "]".
+     * @expectedExceptionMessage Path cannot be empty, Line 1
      */
     public function testParseMustFailWhenTableArrayMalformedEmpty()
     {
@@ -535,7 +539,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Syntax error: unexpected token "T_NEWLINE" at line 1
+     * @expectedExceptionMessage New line in unfinished path, Line 1
      */
     public function testParseMustFailWhenTableArrayMalformedBracket()
     {
@@ -547,29 +551,5 @@ toml;
         $this->parser->parse($toml);
     }
 
-    /**
-     * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage The array of tables "albums" has already been defined as previous table
-     */
-    public function testParseMustFailWhenTableArrayImplicit()
-    {
-        $toml = <<<'toml'
-        # This test is a bit tricky. It should fail because the first use of
-        # `[[albums.songs]]` without first declaring `albums` implies that `albums`
-        # must be a table. The alternative would be quite weird. Namely, it wouldn't
-        # comply with the TOML spec: "Each double-bracketed sub-table will belong to
-        # the most *recently* defined table element *above* it."
-        #
-        # This is in contrast to the *valid* test, table-array-implicit where
-        # `[[albums.songs]]` works by itself, so long as `[[albums]]` isn't declared
-        # later. (Although, `[albums]` could be.)
-        [[albums.songs]]
-        name = "Glory Days"
-
-        [[albums]]
-        name = "Born in the USA"
-toml;
-
-        $this->parser->parse($toml);
-    }
+    
 }

--- a/tests/ParserInvalidTest.php
+++ b/tests/ParserInvalidTest.php
@@ -525,7 +525,7 @@ toml;
 
     /**
      * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
-     * @expectedExceptionMessage Path cannot be empty, Line 1
+     * @expectedExceptionMessage AOT Segment cannot be empty, Line 1
      */
     public function testParseMustFailWhenTableArrayMalformedEmpty()
     {
@@ -551,5 +551,17 @@ toml;
         $this->parser->parse($toml);
     }
 
-    
+    /**
+     * @expectedException Yosymfony\ParserUtils\SyntaxErrorException
+     * @expectedExceptionMessage AOT Segment cannot be empty, Line 1
+     */
+    public function testParseAOTSegmentNoneEmpty()
+    {
+        $toml = <<<'toml'
+        [[albums].[]]
+        name = "Born to Run"
+toml;
+
+        $this->parser->parse($toml);
+    }    
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -17,6 +17,7 @@ use Yosymfony\Toml\Lexer;
 
 class ParserTest extends TestCase
 {
+
     private $parser;
 
     public function setUp()
@@ -47,7 +48,7 @@ toml;
         $this->assertEquals([
             't' => true,
             'f' => false,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseIntegers()
@@ -66,7 +67,7 @@ toml;
             'neganswer' => -42,
             'positive' => 90,
             'underscore' => 12345,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseLongIntegers()
@@ -81,7 +82,7 @@ toml;
         $this->assertEquals([
             'answer' => 9223372036854775807,
             'neganswer' => -9223372036854775808,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseFloats()
@@ -108,7 +109,7 @@ toml;
             'exponent3' => -0.02,
             'exponent4' => 6.6259999999999998E-34,
             'underscore' => 6.6259999999999998E-34,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseLongFloats()
@@ -123,7 +124,7 @@ toml;
         $this->assertEquals([
             'longpi' => 3.141592653589793,
             'neglongpi' => -3.141592653589793
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseBasicStringsWithASimpleString()
@@ -132,7 +133,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 'You are not drinking enough whisky.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAnEmptyString()
@@ -141,10 +142,10 @@ toml;
 
         $this->assertEquals([
             'answer' => '',
-        ], $array);
+                ], $array);
     }
 
-    public function testParseMustParseStringsWithEscapedCharacters() : void
+    public function testParseMustParseStringsWithEscapedCharacters(): void
     {
         $toml = <<<'toml'
         backspace = "This string has a \b backspace character."
@@ -169,7 +170,7 @@ toml;
             'backslash' => 'This string has a \\ backslash character.',
             'notunicode1' => 'This string does not have a unicode \\u escape.',
             'notunicode2' => 'This string does not have a unicode \\u0075 escape.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseStringsWithPound()
@@ -183,7 +184,7 @@ toml;
         $this->assertEquals([
             'pound' => 'We see no # comments here.',
             'poundcomment' => 'But there are # some comments here.'
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseWithUnicodeCharacterEscaped()
@@ -198,7 +199,7 @@ toml;
         $this->assertEquals([
             'answer4' => json_decode('"\u03B4"'),
             'answer8' => json_decode('"\u0000\u03B4"'),
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseStringWithALiteralUnicodeCharacter()
@@ -207,7 +208,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 'δ',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseMultilineStrings()
@@ -248,7 +249,7 @@ toml;
             'equivalent_one' => 'The quick brown fox jumps over the lazy dog.',
             'equivalent_two' => 'The quick brown fox jumps over the lazy dog.',
             'equivalent_three' => 'The quick brown fox jumps over the lazy dog.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseLiteralStrings()
@@ -273,7 +274,7 @@ toml;
             'carriage' => 'This string has a \r carriage return character.',
             'slash' => 'This string has a \/ slash character.',
             'backslash' => 'This string has a \\\\ backslash character.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseMultilineLiteralStrings()
@@ -296,7 +297,7 @@ toml;
             'oneline' => "This string has a ' quote character.",
             'firstnl' => "This string has a ' quote character.",
             'multiline' => "This string\nhas ' a quote character\nand more than\none newline\nin it.",
-        ], $array);
+                ], $array);
     }
 
     public function testDatetime()
@@ -320,7 +321,7 @@ toml;
             'bestdayever4' => new \Datetime('1979-05-27T07:32:00'),
             'bestdayever5' => new \Datetime('1979-05-27T00:32:00.999999'),
             'bestdayever6' => new \Datetime('1979-05-27'),
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseArraysWithNoSpaces()
@@ -328,8 +329,8 @@ toml;
         $array = $this->parser->parse('ints = [1,2,3]');
 
         $this->assertEquals([
-            'ints' => [1,2,3],
-        ], $array);
+            'ints' => [1, 2, 3],
+                ], $array);
     }
 
     public function testParseMustParseHeterogeneousArrays()
@@ -338,11 +339,11 @@ toml;
 
         $this->assertEquals([
             'mixed' => [
-                [1,2],
+                [1, 2],
                 ['a', 'b'],
                 [1.1, 2.1],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseArraysNested()
@@ -354,7 +355,7 @@ toml;
                 ['a'],
                 ['b']
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testArrayEmpty()
@@ -371,7 +372,7 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseArrays()
@@ -407,7 +408,7 @@ toml;
                 new \DateTime('1979-05-27T07:32:00Z'),
                 new \DateTime('2006-06-01T11:00:00Z'),
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAKeyWithoutNameSpacesAroundEqualSign()
@@ -416,7 +417,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 42,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseKeyWithSpace()
@@ -427,7 +428,7 @@ toml;
 
         $this->assertEquals([
             'a b' => 1,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseKeyWithSpecialCharacters()
@@ -436,7 +437,7 @@ toml;
 
         $this->assertEquals([
             '~!@$^&*()_+-`1234567890[]|/?><.,;:\'' => 1,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAnEmptyTable()
@@ -445,7 +446,7 @@ toml;
 
         $this->assertEquals([
             'a' => [],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableWithAWhiteSpaceInTheName()
@@ -454,7 +455,7 @@ toml;
 
         $this->assertEquals([
             'valid key' => [],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableAQuotedName()
@@ -472,7 +473,7 @@ toml;
                     'type' => 'pug',
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableWithAPoundInTheName()
@@ -488,7 +489,7 @@ toml;
             'key#group' => [
                 'answer' => 42,
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableAndASubtableEmpties()
@@ -503,7 +504,7 @@ toml;
             'a' => [
                 'b' => [],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableWithImplicitGroups()
@@ -523,7 +524,7 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAImplicitAndExplicitAfterTable()
@@ -541,13 +542,13 @@ toml;
         $this->assertEquals([
             'a' => [
                 'better' => 43,
-                'b' =>  [
+                'b' => [
                     'c' => [
                         'answer' => 42,
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseImplicitAndExplicitTableBefore()
@@ -565,13 +566,13 @@ toml;
         $this->assertEquals([
             'a' => [
                 'better' => 43,
-                'b' =>  [
+                'b' => [
                     'c' => [
                         'answer' => 42,
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseInlineTableEmpty()
@@ -580,7 +581,7 @@ toml;
 
         $this->assertEquals([
             'name' => [],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseInlineTableOneElement()
@@ -591,7 +592,7 @@ toml;
             'name' => [
                 'first' => 'Tom'
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAnInlineTableDefinedInATable()
@@ -609,7 +610,7 @@ toml;
                     'name' => 'Donald Duck'
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseInlineTableExamples()
@@ -654,7 +655,7 @@ toml;
             'another' => [
                 'number' => 1,
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseTableArrayImplicit()
@@ -676,7 +677,86 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
+    }
+
+    public function testTakeSingleQuoteKeys()
+    {
+        $toml = <<<'toml'
+        [test]
+        'Like me' = 'yes'
+toml;
+        $array = $this->parser->parse($toml);
+
+        $this->assertEquals([
+            'test' => [
+                'Like me' => 'yes',
+            ]
+                ], $array);
+    }
+
+    public function testTomlSiteExample1()
+    {
+        $toml = <<<'toml'
+[[fruit.blah]]
+  name = "apple"
+
+  [fruit.blah.physical]
+    color = "red"
+    shape = "round"
+
+[[fruit.blah]]
+  name = "banana"
+
+  [fruit.blah.physical]
+    color = "yellow"
+    shape = "bent"
+toml;
+        $array = $this->parser->parse($toml);
+
+        $this->assertEquals([
+            'fruit' => [
+                [
+                    'blah' => [
+                        [
+                            'name' => 'apple',
+                            'physical' => [
+                                'color' => "red",
+                                'shape' => "round",
+                            ],
+                        ],
+                        [
+                            'name' => 'banana',
+                            'physical' => [
+                                'color' => "yellow",
+                                'shape' => "bent",
+                            ],
+                        ]
+                    ]
+                ],
+            ]
+                ], $array);
+    }
+
+    public function testConvertIntegerKeys()
+    {
+        $toml = <<<'toml'
+        [sequence]
+        -1 = 'detect person'
+        0 = 'say hello'
+        1 = 'chat'
+        10 = 'say bye'
+toml;
+        $array = $this->parser->parse($toml);
+
+        $this->assertEquals([
+            'sequence' => [
+                '-1' => 'detect person',
+                '0' => 'say hello',
+                '1' => 'chat',
+                '10' => 'say bye'
+            ]
+                ], $array);
     }
 
     public function testParseMustParseTableArrayOne()
@@ -696,7 +776,7 @@ toml;
                     'last_name' => 'Springsteen',
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseTableArrayMany()
@@ -732,7 +812,7 @@ toml;
                     'last_name' => 'Seger',
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseTableArrayNest()
@@ -776,7 +856,7 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     /**
@@ -805,7 +885,7 @@ toml;
                     ['name' => 'granny smith'],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseCommentsEverywhere()
@@ -869,6 +949,7 @@ toml;
                 'boring' => false,
                 'perfection' => [6, 28, 496],
             ],
-        ], $array);
+                ], $array);
     }
+
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -17,6 +17,7 @@ use Yosymfony\Toml\Lexer;
 
 class ParserTest extends TestCase
 {
+
     private $parser;
 
     public function setUp()
@@ -47,7 +48,7 @@ toml;
         $this->assertEquals([
             't' => true,
             'f' => false,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseIntegers()
@@ -66,7 +67,7 @@ toml;
             'neganswer' => -42,
             'positive' => 90,
             'underscore' => 12345,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseLongIntegers()
@@ -81,7 +82,7 @@ toml;
         $this->assertEquals([
             'answer' => 9223372036854775807,
             'neganswer' => -9223372036854775808,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseFloats()
@@ -108,7 +109,7 @@ toml;
             'exponent3' => -0.02,
             'exponent4' => 6.6259999999999998E-34,
             'underscore' => 6.6259999999999998E-34,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseLongFloats()
@@ -123,7 +124,7 @@ toml;
         $this->assertEquals([
             'longpi' => 3.141592653589793,
             'neglongpi' => -3.141592653589793
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseBasicStringsWithASimpleString()
@@ -132,7 +133,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 'You are not drinking enough whisky.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAnEmptyString()
@@ -141,10 +142,10 @@ toml;
 
         $this->assertEquals([
             'answer' => '',
-        ], $array);
+                ], $array);
     }
 
-    public function testParseMustParseStringsWithEscapedCharacters() : void
+    public function testParseMustParseStringsWithEscapedCharacters(): void
     {
         $toml = <<<'toml'
         backspace = "This string has a \b backspace character."
@@ -169,7 +170,7 @@ toml;
             'backslash' => 'This string has a \\ backslash character.',
             'notunicode1' => 'This string does not have a unicode \\u escape.',
             'notunicode2' => 'This string does not have a unicode \\u0075 escape.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseStringsWithPound()
@@ -183,7 +184,7 @@ toml;
         $this->assertEquals([
             'pound' => 'We see no # comments here.',
             'poundcomment' => 'But there are # some comments here.'
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseWithUnicodeCharacterEscaped()
@@ -198,7 +199,7 @@ toml;
         $this->assertEquals([
             'answer4' => json_decode('"\u03B4"'),
             'answer8' => json_decode('"\u0000\u03B4"'),
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseStringWithALiteralUnicodeCharacter()
@@ -207,7 +208,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 'δ',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseMultilineStrings()
@@ -248,7 +249,7 @@ toml;
             'equivalent_one' => 'The quick brown fox jumps over the lazy dog.',
             'equivalent_two' => 'The quick brown fox jumps over the lazy dog.',
             'equivalent_three' => 'The quick brown fox jumps over the lazy dog.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseLiteralStrings()
@@ -273,7 +274,7 @@ toml;
             'carriage' => 'This string has a \r carriage return character.',
             'slash' => 'This string has a \/ slash character.',
             'backslash' => 'This string has a \\\\ backslash character.',
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseMultilineLiteralStrings()
@@ -296,7 +297,7 @@ toml;
             'oneline' => "This string has a ' quote character.",
             'firstnl' => "This string has a ' quote character.",
             'multiline' => "This string\nhas ' a quote character\nand more than\none newline\nin it.",
-        ], $array);
+                ], $array);
     }
 
     public function testDatetime()
@@ -320,7 +321,7 @@ toml;
             'bestdayever4' => new \Datetime('1979-05-27T07:32:00'),
             'bestdayever5' => new \Datetime('1979-05-27T00:32:00.999999'),
             'bestdayever6' => new \Datetime('1979-05-27'),
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseArraysWithNoSpaces()
@@ -328,8 +329,8 @@ toml;
         $array = $this->parser->parse('ints = [1,2,3]');
 
         $this->assertEquals([
-            'ints' => [1,2,3],
-        ], $array);
+            'ints' => [1, 2, 3],
+                ], $array);
     }
 
     public function testParseMustParseHeterogeneousArrays()
@@ -338,11 +339,11 @@ toml;
 
         $this->assertEquals([
             'mixed' => [
-                [1,2],
+                [1, 2],
                 ['a', 'b'],
                 [1.1, 2.1],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseArraysNested()
@@ -354,7 +355,7 @@ toml;
                 ['a'],
                 ['b']
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testArrayEmpty()
@@ -371,7 +372,7 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseArrays()
@@ -407,7 +408,7 @@ toml;
                 new \DateTime('1979-05-27T07:32:00Z'),
                 new \DateTime('2006-06-01T11:00:00Z'),
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAKeyWithoutNameSpacesAroundEqualSign()
@@ -416,7 +417,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 42,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseKeyWithSpace()
@@ -427,7 +428,7 @@ toml;
 
         $this->assertEquals([
             'a b' => 1,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseKeyWithSpecialCharacters()
@@ -436,7 +437,7 @@ toml;
 
         $this->assertEquals([
             '~!@$^&*()_+-`1234567890[]|/?><.,;:\'' => 1,
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAnEmptyTable()
@@ -445,7 +446,7 @@ toml;
 
         $this->assertEquals([
             'a' => [],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableWithAWhiteSpaceInTheName()
@@ -454,7 +455,7 @@ toml;
 
         $this->assertEquals([
             'valid key' => [],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableAQuotedName()
@@ -472,7 +473,7 @@ toml;
                     'type' => 'pug',
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableWithAPoundInTheName()
@@ -488,7 +489,7 @@ toml;
             'key#group' => [
                 'answer' => 42,
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableAndASubtableEmpties()
@@ -503,7 +504,7 @@ toml;
             'a' => [
                 'b' => [],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseATableWithImplicitGroups()
@@ -523,7 +524,7 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAImplicitAndExplicitAfterTable()
@@ -541,13 +542,13 @@ toml;
         $this->assertEquals([
             'a' => [
                 'better' => 43,
-                'b' =>  [
+                'b' => [
                     'c' => [
                         'answer' => 42,
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseImplicitAndExplicitTableBefore()
@@ -565,13 +566,13 @@ toml;
         $this->assertEquals([
             'a' => [
                 'better' => 43,
-                'b' =>  [
+                'b' => [
                     'c' => [
                         'answer' => 42,
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseInlineTableEmpty()
@@ -580,7 +581,7 @@ toml;
 
         $this->assertEquals([
             'name' => [],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseInlineTableOneElement()
@@ -591,7 +592,7 @@ toml;
             'name' => [
                 'first' => 'Tom'
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseAnInlineTableDefinedInATable()
@@ -609,7 +610,7 @@ toml;
                     'name' => 'Donald Duck'
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseInlineTableExamples()
@@ -654,7 +655,7 @@ toml;
             'another' => [
                 'number' => 1,
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseTableArrayImplicit()
@@ -676,7 +677,7 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testTakeSingleQuoteKeys()
@@ -757,7 +758,7 @@ toml;
             ]
                 ], $array);
     }
-    
+
     public function testParseMustParseTableArrayOne()
     {
         $toml = <<<'toml'
@@ -775,7 +776,7 @@ toml;
                     'last_name' => 'Springsteen',
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseTableArrayMany()
@@ -811,7 +812,7 @@ toml;
                     'last_name' => 'Seger',
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseTableArrayNest()
@@ -855,7 +856,7 @@ toml;
                     ],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     /**
@@ -884,7 +885,7 @@ toml;
                     ['name' => 'granny smith'],
                 ],
             ],
-        ], $array);
+                ], $array);
     }
 
     public function testParseMustParseCommentsEverywhere()
@@ -948,6 +949,118 @@ toml;
                 'boring' => false,
                 'perfection' => [6, 28, 496],
             ],
-        ], $array);
+                ], $array);
     }
+
+    public function testParseAOTDoublePathSegment()
+    {
+        $toml = <<<'toml'
+        #
+        [[albums.songs]]
+        name = "Glory Days"
+
+        [[albums]]
+        name = "Born in the USA"
+toml;
+
+        $array = $this->parser->parse($toml);
+
+        $this->assertEquals([
+            'albums' => [
+                [
+                    'songs' => [
+                        [
+                            'name' => "Glory Days",
+                        ]
+                    ]
+                ],
+                [
+                    'name' => "Born in the USA"
+                ]
+            ],
+                ], $array);
+    }
+
+    public function testParseMixedAOT1()
+    {
+        $toml = <<<'toml'
+        # Make wierd stuff easier
+        # This example then becomes just weird data layout, so I'm moving
+        # this from ParserInvalidTest to ParserTest, and stating what the expected
+        # output will be, and then format it better.
+        #
+        [[albums].songs]
+        name = "Glory Days"
+
+        [[albums]] # name of album
+            name = "Born in the USA"
+            
+        [[albums].songs] # name of song in same album
+            name = "Born in the USA"
+toml;
+
+        $array = $this->parser->parse($toml);
+
+        $this->assertEquals([
+            'albums' => [
+                [
+                    'songs' => [
+                        'name' => "Glory Days",
+                    ]
+                ],
+                [
+                    'name' => "Born in the USA",
+                    'songs' => [
+                        'name' => "Born in the USA"
+                    ]
+                ]
+            ],
+                ], $array);
+    }
+
+    public function testMixedAOT2()
+    {
+        $toml = <<<'toml'
+# Table appendage physical goes in current AOT-T, no matter what
+# internal brackets used after AOT pattern established
+# only a terminal AOT increments adds a latest table
+
+[fruit.[nice]] # new blah
+  name = "apple"
+
+  [fruit.[nice].physical] # same blah
+    color = "red"
+    shape = "round"
+
+[fruit.[nice]] # new blah
+  name = "banana"
+
+  [fruit.nice.physical] # same blah
+    color = "yellow"
+    shape = "bent"
+toml;
+        $array = $this->parser->parse($toml);
+
+        $this->assertEquals([
+            'fruit' => [
+                'nice' => [
+                    [
+                        'name' => 'apple',
+                        'physical' => [
+                            'color' => "red",
+                            'shape' => "round",
+                        ],
+                    ],
+                    [
+                        'name' => 'banana',
+                        'physical' => [
+                            'color' => "yellow",
+                            'shape' => "bent",
+                        ],
+                    ]
+                ]
+            ]
+                ], $array);
+    }
+
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -17,7 +17,6 @@ use Yosymfony\Toml\Lexer;
 
 class ParserTest extends TestCase
 {
-
     private $parser;
 
     public function setUp()
@@ -48,7 +47,7 @@ toml;
         $this->assertEquals([
             't' => true,
             'f' => false,
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseIntegers()
@@ -67,7 +66,7 @@ toml;
             'neganswer' => -42,
             'positive' => 90,
             'underscore' => 12345,
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseLongIntegers()
@@ -82,7 +81,7 @@ toml;
         $this->assertEquals([
             'answer' => 9223372036854775807,
             'neganswer' => -9223372036854775808,
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseFloats()
@@ -109,7 +108,7 @@ toml;
             'exponent3' => -0.02,
             'exponent4' => 6.6259999999999998E-34,
             'underscore' => 6.6259999999999998E-34,
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseLongFloats()
@@ -124,7 +123,7 @@ toml;
         $this->assertEquals([
             'longpi' => 3.141592653589793,
             'neglongpi' => -3.141592653589793
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseBasicStringsWithASimpleString()
@@ -133,7 +132,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 'You are not drinking enough whisky.',
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseAnEmptyString()
@@ -142,10 +141,10 @@ toml;
 
         $this->assertEquals([
             'answer' => '',
-                ], $array);
+        ], $array);
     }
 
-    public function testParseMustParseStringsWithEscapedCharacters(): void
+    public function testParseMustParseStringsWithEscapedCharacters() : void
     {
         $toml = <<<'toml'
         backspace = "This string has a \b backspace character."
@@ -170,7 +169,7 @@ toml;
             'backslash' => 'This string has a \\ backslash character.',
             'notunicode1' => 'This string does not have a unicode \\u escape.',
             'notunicode2' => 'This string does not have a unicode \\u0075 escape.',
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseStringsWithPound()
@@ -184,7 +183,7 @@ toml;
         $this->assertEquals([
             'pound' => 'We see no # comments here.',
             'poundcomment' => 'But there are # some comments here.'
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseWithUnicodeCharacterEscaped()
@@ -199,7 +198,7 @@ toml;
         $this->assertEquals([
             'answer4' => json_decode('"\u03B4"'),
             'answer8' => json_decode('"\u0000\u03B4"'),
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseStringWithALiteralUnicodeCharacter()
@@ -208,7 +207,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 'δ',
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseMultilineStrings()
@@ -249,7 +248,7 @@ toml;
             'equivalent_one' => 'The quick brown fox jumps over the lazy dog.',
             'equivalent_two' => 'The quick brown fox jumps over the lazy dog.',
             'equivalent_three' => 'The quick brown fox jumps over the lazy dog.',
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseLiteralStrings()
@@ -274,7 +273,7 @@ toml;
             'carriage' => 'This string has a \r carriage return character.',
             'slash' => 'This string has a \/ slash character.',
             'backslash' => 'This string has a \\\\ backslash character.',
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseMultilineLiteralStrings()
@@ -297,7 +296,7 @@ toml;
             'oneline' => "This string has a ' quote character.",
             'firstnl' => "This string has a ' quote character.",
             'multiline' => "This string\nhas ' a quote character\nand more than\none newline\nin it.",
-                ], $array);
+        ], $array);
     }
 
     public function testDatetime()
@@ -321,7 +320,7 @@ toml;
             'bestdayever4' => new \Datetime('1979-05-27T07:32:00'),
             'bestdayever5' => new \Datetime('1979-05-27T00:32:00.999999'),
             'bestdayever6' => new \Datetime('1979-05-27'),
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseArraysWithNoSpaces()
@@ -329,8 +328,8 @@ toml;
         $array = $this->parser->parse('ints = [1,2,3]');
 
         $this->assertEquals([
-            'ints' => [1, 2, 3],
-                ], $array);
+            'ints' => [1,2,3],
+        ], $array);
     }
 
     public function testParseMustParseHeterogeneousArrays()
@@ -339,11 +338,11 @@ toml;
 
         $this->assertEquals([
             'mixed' => [
-                [1, 2],
+                [1,2],
                 ['a', 'b'],
                 [1.1, 2.1],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseArraysNested()
@@ -355,7 +354,7 @@ toml;
                 ['a'],
                 ['b']
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testArrayEmpty()
@@ -372,7 +371,7 @@ toml;
                     ],
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseArrays()
@@ -408,7 +407,7 @@ toml;
                 new \DateTime('1979-05-27T07:32:00Z'),
                 new \DateTime('2006-06-01T11:00:00Z'),
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseAKeyWithoutNameSpacesAroundEqualSign()
@@ -417,7 +416,7 @@ toml;
 
         $this->assertEquals([
             'answer' => 42,
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseKeyWithSpace()
@@ -428,7 +427,7 @@ toml;
 
         $this->assertEquals([
             'a b' => 1,
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseKeyWithSpecialCharacters()
@@ -437,7 +436,7 @@ toml;
 
         $this->assertEquals([
             '~!@$^&*()_+-`1234567890[]|/?><.,;:\'' => 1,
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseAnEmptyTable()
@@ -446,7 +445,7 @@ toml;
 
         $this->assertEquals([
             'a' => [],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseATableWithAWhiteSpaceInTheName()
@@ -455,7 +454,7 @@ toml;
 
         $this->assertEquals([
             'valid key' => [],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseATableAQuotedName()
@@ -473,7 +472,7 @@ toml;
                     'type' => 'pug',
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseATableWithAPoundInTheName()
@@ -489,7 +488,7 @@ toml;
             'key#group' => [
                 'answer' => 42,
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseATableAndASubtableEmpties()
@@ -504,7 +503,7 @@ toml;
             'a' => [
                 'b' => [],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseATableWithImplicitGroups()
@@ -524,7 +523,7 @@ toml;
                     ],
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseAImplicitAndExplicitAfterTable()
@@ -542,13 +541,13 @@ toml;
         $this->assertEquals([
             'a' => [
                 'better' => 43,
-                'b' => [
+                'b' =>  [
                     'c' => [
                         'answer' => 42,
                     ],
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseImplicitAndExplicitTableBefore()
@@ -566,13 +565,13 @@ toml;
         $this->assertEquals([
             'a' => [
                 'better' => 43,
-                'b' => [
+                'b' =>  [
                     'c' => [
                         'answer' => 42,
                     ],
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseInlineTableEmpty()
@@ -581,7 +580,7 @@ toml;
 
         $this->assertEquals([
             'name' => [],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseInlineTableOneElement()
@@ -592,7 +591,7 @@ toml;
             'name' => [
                 'first' => 'Tom'
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseAnInlineTableDefinedInATable()
@@ -610,7 +609,7 @@ toml;
                     'name' => 'Donald Duck'
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseInlineTableExamples()
@@ -655,7 +654,7 @@ toml;
             'another' => [
                 'number' => 1,
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseTableArrayImplicit()
@@ -677,7 +676,7 @@ toml;
                     ],
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testTakeSingleQuoteKeys()
@@ -758,7 +757,7 @@ toml;
             ]
                 ], $array);
     }
-
+    
     public function testParseMustParseTableArrayOne()
     {
         $toml = <<<'toml'
@@ -776,7 +775,7 @@ toml;
                     'last_name' => 'Springsteen',
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseTableArrayMany()
@@ -812,7 +811,7 @@ toml;
                     'last_name' => 'Seger',
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseTableArrayNest()
@@ -856,7 +855,7 @@ toml;
                     ],
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     /**
@@ -885,7 +884,7 @@ toml;
                     ['name' => 'granny smith'],
                 ],
             ],
-                ], $array);
+        ], $array);
     }
 
     public function testParseMustParseCommentsEverywhere()
@@ -949,7 +948,6 @@ toml;
                 'boring' => false,
                 'perfection' => [6, 28, 496],
             ],
-                ], $array);
+        ], $array);
     }
-
 }


### PR DESCRIPTION
Testing on some of the TOML github examples, and reading the documentation, and testing on some of my website toml configuration files, suggests that the current branch doesn't do Array of Table and nested tables quite right, and looks to me to be worth getting it right. It is a little bit hard to tell, almost inscrutable, from the official TOML scarce documentation. Does anyone have really detailed specification?   
The AOT stack keeps track of nested AOT while they are still in context.  Usage of finds the current-in-use item of AOT, or adds a new table for repeats.
I also enlarged the parse key specification to include encounters with single quoted strings, and bare integers which are converted to string.
I am not sure that storing the key paths is all that much independently useful when not debugging the parser, so I've made it optional.
I like checking for the BOM when loading raw file contents, so I added a parseFile in the Parser class.