### PR TITLE
Added a new function build Toml string from a multidimensional array automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,74 @@ The result:
         [[fruit.variety]]
         name = "plantain"
 
+### TomlBuilderFromArray
+You can also create a TOML string from an array with TomlBuilderFromArray automatically. You could save the result to a Toml file.
+
+```php
+    $array = [
+        'a1' => [
+            'b1' => [
+                'c1'=>[
+                    'c1'=>[
+                        'c1'=>0
+                    ]
+                ]
+            ],
+            'b2' => 2,
+        ],
+        'a2' => [
+            [
+                'b1' => [
+                    'c1' => [
+                        'd1'=>[
+                            'd1'=>[
+                                1,2,3
+                            ]
+                        ]
+                    ],
+                    'c2' => 100
+                ]
+            ],
+            [
+                'b2' => [
+                    'c1' => 200,
+                    'c2' => 200,
+                ]
+            ]
+        ],
+    ];
+    $tbfa = new \Yosymfony\Toml\TomlBuilderFromArray($config);
+    $result = $tbfa->convert();
+```
+The result:
+```
+[a1]
+b2 = 2
+
+[a1.b1]
+
+[a1.b1.c1]
+
+[a1.b1.c1.c1]
+c1 = 0
+
+[[a2]]
+
+[a2.b1]
+c2 = 100
+
+[a2.b1.c1]
+
+[a2.b1.c1.d1]
+d1 = [1, 2, 3]
+
+[[a2]]
+
+[a2.b2]
+c1 = 200
+c2 = 200
+```
+
 Deprecated method
 -----------------
 The following method will be eliminated in version 2.0.0

--- a/src/Toml.php
+++ b/src/Toml.php
@@ -41,6 +41,7 @@ class Toml
     {
         try {
             $data = self::doParse($input, $resultAsObject);
+            is_null($data) or self::postProcess($data);
         } catch (SyntaxErrorException $e) {
             $exception = new ParseException($e->getMessage(), -1, null, null, $e);
 
@@ -112,5 +113,28 @@ class Toml
         }
 
         return empty($values) ? null : $values;
+    }
+
+    /**
+     * remove empty element from $arr recursively
+     * @param $arr array|object
+     * @return array|object
+     */
+    private static function postProcess(&$arr)
+    {
+        if (!is_array($arr) && !is_object($arr)) {
+            throw new ParseException('Param must be an array or a object');
+        }
+        foreach ($arr as $key => &$value) {
+            if (is_array($value) || is_object($value)) {
+                self::postProcess($value);
+            }
+            if ((is_array($value) && count($value) == 0 && is_numeric($key))) {
+                unset($arr[$key]);
+            }
+            if (is_object($value) && 0 == count((array)$value)) {
+                unset($arr->$key);
+            }
+        }
     }
 }

--- a/src/Toml.php
+++ b/src/Toml.php
@@ -116,23 +116,23 @@ class Toml
     }
 
     /**
-     * remove empty element from $arr recursively
+     * Remove empty element from $arr recursively
      * @param $arr array|object
      * @return array|object
      */
     private static function postProcess(&$arr)
     {
         if (!is_array($arr) && !is_object($arr)) {
-            throw new ParseException('Param must be an array or a object');
+            throw new ParseException('Param must be an array or an object');
         }
         foreach ($arr as $key => &$value) {
             if (is_array($value) || is_object($value)) {
                 self::postProcess($value);
             }
-            if ((is_array($value) && count($value) == 0 && is_numeric($key))) {
+            if (is_array($value) && count($value) == 0 && is_numeric($key)) {
                 unset($arr[$key]);
             }
-            if (is_object($value) && 0 == count((array)$value)) {
+            if (is_object($value) && 0 == count((array)$value) && is_numeric($key)) {
                 unset($arr->$key);
             }
         }

--- a/src/TomlBuilder.php
+++ b/src/TomlBuilder.php
@@ -288,7 +288,7 @@ class TomlBuilder
 
     private function addKeyTable(string $key) : void
     {
-        if (in_array($key, $this->keyListArryOfTables, true)) {
+        if (array_key_exists($key, $this->keyListArryOfTables)) {
             throw new DumpException(
                 sprintf('The table %s has already been defined as previous array of tables', $key)
             );
@@ -365,7 +365,7 @@ class TomlBuilder
 
             $key = implode('.', $keyParts);
 
-            if (!in_array($key, $this->keyListArryOfTables, true)) {
+            if (!array_key_exists($key, $this->keyListArryOfTables)) {
                 return true;
             }
         }

--- a/src/TomlBuilder.php
+++ b/src/TomlBuilder.php
@@ -288,7 +288,7 @@ class TomlBuilder
 
     private function addKeyTable(string $key) : void
     {
-        if (in_array($key, $this->keyListArryOfTables)) {
+        if (in_array($key, $this->keyListArryOfTables, true)) {
             throw new DumpException(
                 sprintf('The table %s has already been defined as previous array of tables', $key)
             );
@@ -308,7 +308,7 @@ class TomlBuilder
             return;
         }
 
-        if (in_array($key, $this->keyListInvalidArrayOfTables)) {
+        if (in_array($key, $this->keyListInvalidArrayOfTables, true)) {
             throw new DumpException(
                 sprintf('The array of tables %s has already been defined as previous table', $key)
             );
@@ -343,7 +343,7 @@ class TomlBuilder
 
     private function addKeyToKeyList(string $key) : void
     {
-        if (in_array($key, $this->keyList)) {
+        if (in_array($key, $this->keyList, true)) {
             throw new DumpException(sprintf('Syntax error: the key "%s" has already been defined', $key));
         }
 
@@ -365,7 +365,7 @@ class TomlBuilder
 
             $key = implode('.', $keyParts);
 
-            if (false == in_array($key, $this->keyListArryOfTables)) {
+            if (!in_array($key, $this->keyListArryOfTables, true)) {
                 return true;
             }
         }

--- a/src/TomlBuilderFromArray.php
+++ b/src/TomlBuilderFromArray.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Yosymfony\Toml;
+
+use Yosymfony\Toml\Exception\ParseException;
+
+class TomlBuilderFromArray
+{
+    private $src;
+    private $tb;
+    private $keyStack = [];
+
+    public function __construct($src)
+    {
+        if (is_object($src)) {
+            $src = $this->obj2Arr($src);
+        }
+        if (!is_array($src)) {
+            throw new ParseException('input must be an array');
+        }
+
+        $this->tb = new TomlBuilder();
+        $this->src = $src;
+    }
+
+    public function convert()
+    {
+        if (!is_array($this->src)) {
+            throw new ParseException('input must be an array');
+        }
+
+        $this->arrange($this->src);
+        $this->dumpItem($this->src);
+        return $this->tb->getTomlString();
+    }
+
+    /**
+     * Move simple elements to the front part of array recursively.
+     * @param $array
+     */
+    private function arrange(&$array)
+    {
+        $is_array = [];
+        $isnot_array = [];
+        foreach ($array as $key => $value) {
+            if (is_array($value) && !empty($value)) {
+                $this->arrange($value);
+                $is_array[$key] = $value;
+            } else {
+                $isnot_array[$key] = $value;
+            }
+        }
+        $array = array_merge($isnot_array, $is_array);
+    }
+
+    private function dumpItem($item, $key = '')
+    {
+        switch (true) {
+            case is_array($item) || is_object($item):
+                if ($this->is_assoc($item)) {
+                    if (!is_numeric($key) && !empty($key)) {
+                        $added = true;
+                        array_push($this->keyStack, $key);
+                        $this->tb->addTable($this->getKeys());
+                    }
+                    foreach ($item as $k => $v) {
+                        $this->dumpItem($v, $k);
+                    }
+                    if (isset($added) && $added) {
+                        array_pop($this->keyStack);
+                    }
+                } else {
+                    if ($this->is_1_dim($item) && !empty($key)) {
+                        $this->tb->addValue($key, $item);
+                    } else {
+                        foreach ($item as $k => $v) {
+                            if (!is_numeric($key) && !empty($key)) {
+                                array_push($this->keyStack, $key);
+                            }
+                            $this->tb->addArrayOfTable($this->getKeys());
+                            $this->dumpItem($v, $k);
+                            if (!is_numeric($key) && !empty($key)) {
+                                array_pop($this->keyStack);
+                            }
+                        }
+                    }
+                }
+                break;
+            default:
+                $this->tb->addValue($key, $item);
+                break;
+        }
+    }
+
+    private function is_assoc($array)
+    {
+        if (is_object($array)) {
+            return true;
+        }
+        return (bool)count(array_filter(array_keys($array), 'is_string'));
+    }
+
+    private function getKeys()
+    {
+        return implode('.', $this->keyStack);
+    }
+
+    private function is_1_dim($arr)
+    {
+        if (is_object($arr)) {
+            $arr = $this->obj2Arr($arr);
+        }
+        return count($arr) == count($arr, 1);
+    }
+
+    private function obj2Arr($obj)
+    {
+        return json_decode(json_encode($obj), true);
+    }
+
+}

--- a/tests/TomlBuilderFromArrayInvalidTest.php
+++ b/tests/TomlBuilderFromArrayInvalidTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yosymfony\Toml\tests;
+
+
+use PHPUnit\Framework\TestCase;
+use Yosymfony\Toml\TomlBuilderFromArray;
+
+class TomlBuilderFromArrayInvalidTest extends TestCase
+{
+    /**
+     * @expectedException Yosymfony\Toml\Exception\ParseException
+     */
+    public function testEmptyString()
+    {
+        $tbfa = new TomlBuilderFromArray('');
+        $this->assertNotNull($tbfa->convert());
+    }
+
+    /**
+     * @expectedException Yosymfony\Toml\Exception\DumpException
+     */
+    public function testInvalidType()
+    {
+        $fp = fopen('php://input', 'r');
+        $array = [
+            'a' => 123,
+            'b' => $fp
+        ];
+        $tbfa = new TomlBuilderFromArray($array);
+        $tbfa->convert();
+    }
+
+}

--- a/tests/TomlBuilderFromArrayTest.php
+++ b/tests/TomlBuilderFromArrayTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yosymfony\Toml\tests;
+
+
+use PHPUnit\Framework\TestCase;
+use Yosymfony\Toml\Toml;
+use Yosymfony\Toml\TomlBuilderFromArray;
+
+class TomlBuilderFromArrayTest extends TestCase
+{
+    public function testExample()
+    {
+        $config_file = __DIR__ . '/fixtures/array.php';
+        $config = include $config_file;
+
+        $tbfa = new TomlBuilderFromArray($config);
+        $result = $tbfa->convert();
+
+        $this->assertNotNull($result);
+    }
+
+    public function testMultidimensionalArray()
+    {
+        $array = [
+            'a' => [
+                'b' => [
+                    'c' => [
+                        'd' => 999
+                    ]
+                ]
+            ],
+            'b' => '0'
+        ];
+        $tbfa = new TomlBuilderFromArray($array);
+        $this->assertSame(Toml::parse($tbfa->convert())['a']['b']['c']['d'], 999);
+    }
+
+    public function testObject()
+    {
+        $config_file = __DIR__ . '/fixtures/array.php';
+        $config = include $config_file;
+        $object = (object)$config;
+        $tbfa = new TomlBuilderFromArray($object);
+        $this->assertNotNull($tbfa->convert());
+    }
+
+    public function testEmptyArray()
+    {
+        $tbfa = new TomlBuilderFromArray([]);
+        $this->assertEmpty($tbfa->convert());
+    }
+
+    public function testEmptyObject()
+    {
+        $tbfa = new TomlBuilderFromArray((object)[]);
+        $this->assertEmpty($tbfa->convert());
+    }
+
+}

--- a/tests/fixtures/array.php
+++ b/tests/fixtures/array.php
@@ -1,0 +1,53 @@
+<?php
+return array(
+    'd' =>
+        array(),
+    'c' =>
+        array(
+            'a' => 1,
+        ),
+    'b' =>
+        array(
+            'a2' => 2,
+            'a1' =>
+                array(
+                    'fd' =>
+                        array(
+                            'fd' =>
+                                array(
+                                    'a' => 1,
+                                ),
+                        ),
+                ),
+        ),
+    'a' =>
+        array(
+            0 =>
+                array(
+                    'a2' =>
+                        array(
+                            'a4' => 100,
+                            'a3' =>
+                                array(
+                                    'a4' =>
+                                        array(
+                                            'a5' =>
+                                                array(
+                                                    0 => 1,
+                                                    1 => 2,
+                                                    2 => 3,
+                                                ),
+                                        ),
+                                ),
+                        ),
+                ),
+            1 =>
+                array(
+                    'a2' =>
+                        array(
+                            'a3' => 200,
+                            'a4' => 200,
+                        ),
+                ),
+        ),
+);


### PR DESCRIPTION
This function used your existed function `TomlBuilder`.
I also found the bug `#24`.

Example:
```
$array = [
        'a1' => [
            'b1' => [
                'c1'=>[
                    'c1'=>[
                        'c1'=>0
                    ]
                ]
            ],
            'b2' => 2,
        ],
        'a2' => [
            [
                'b1' => [
                    'c1' => [
                        'd1'=>[
                            'd1'=>[
                                1,2,3
                            ]
                        ]
                    ],
                    'c2' => 100
                ]
            ],
            [
                'b2' => [
                    'c1' => 200,
                    'c2' => 200,
                ]
            ]
        ],
    ];
    $tbfa = new \Yosymfony\Toml\TomlBuilderFromArray($config);
    $result1 = $tbfa->convert();
    $result2 = \Yosymfony\Toml\Toml::parse($result1);
```
The result1:
```
[a1]
b2 = 2

[a1.b1]

[a1.b1.c1]

[a1.b1.c1.c1]
c1 = 0

[[a2]]

[a2.b1]
c2 = 100

[a2.b1.c1]

[a2.b1.c1.d1]
d1 = [1, 2, 3]

[[a2]]

[a2.b2]
c1 = 200
c2 = 200
```
The result2:
```
array(
    'a1' =>
        array(
            'b2' => 2,
            'b1' =>
                array(
                    'c1' =>
                        array(
                            'c1' =>
                                array(
                                    'c1' => 0,
                                ),
                        ),
                ),
        ),
    'a2' =>
        array(
            0 =>
                array(
                    'b1' =>
                        array(
                            'c2' => 100,
                            'c1' =>
                                array(
                                    'd1' =>
                                        array(
                                            'd1' =>
                                                array(
                                                    0 => 1,
                                                    1 => 2,
                                                    2 => 3,
                                                ),
                                        ),
                                ),
                        ),
                ),
            1 =>
                array(
                    'b2' =>
                        array(
                            'c1' => 200,
                            'c2' => 200,
                        ),
                ),
        ),
)
```