### PR TITLE
Implicit nullables are deprecated in PHP 8.4

### DIFF
--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -33,7 +33,7 @@ class ParseException extends \RuntimeException
      * @param string|null  $parsedFile The file name where the error occurred
      * @param Exception $previous   The previous exception
      */
-    public function __construct(string $message, int $parsedLine = -1, string $snippet = null, string $parsedFile = null, \Exception $previous = null)
+    public function __construct(string $message, int $parsedLine = -1, ?string $snippet = null, ?string $parsedFile = null, ?\Exception $previous = null)
     {
         $this->parsedFile = $parsedFile;
         $this->parsedLine = $parsedLine;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -578,7 +578,7 @@ class Parser extends AbstractParser
         throw new SyntaxErrorException($msg);
     }
 
-    private function syntaxError($msg, Token $token = null) : void
+    private function syntaxError($msg, ?Token $token = null) : void
     {
         if ($token !== null) {
             $name = $token->getName();


### PR DESCRIPTION
Updated nullable params to explicit